### PR TITLE
fixing short / unwind

### DIFF
--- a/contracts/LendingPair.sol
+++ b/contracts/LendingPair.sol
@@ -286,14 +286,17 @@ contract LendingPair is ERC20, Ownable {
         bentoBox.withdrawShare(collateral, to, amount);
     }
 
+    function _assetBalance() internal returns (uint256) {
+        return bentoBox.shareOf(asset, address(this)).mul(bentoBox.totalBalance(asset)) / bentoBox.totalShare(asset);
+    }
+
     // Withdraws a share of supply (the borrowable token) of the caller to the specified address
     function removeAsset(uint256 share, address to) public {
         // Accrue interest before calculating pool shares in _removeAssetShare
         accrue();
         updateInterestRate();
-        uint256 nonVirtualAssetBalance = bentoBox.totalBalance(asset);
         uint256 amount = _removeAssetShare(msg.sender, share);
-        require(amount <= nonVirtualAssetBalance.sub(totalBorrow), 'BentoBox: not enough liquidity');
+        require(amount <= _assetBalance().sub(totalBorrow), 'BentoBox: not enough liquidity');
         bentoBox.withdrawShare(asset, to, amount);
     }
 

--- a/contracts/LendingPair.sol
+++ b/contracts/LendingPair.sol
@@ -143,7 +143,7 @@ contract LendingPair is ERC20, Ownable {
 
     // Checks if the user is solvent.
     // Has an option to check if the user is solvent in an open/closed liquidation case.
-    function isSolvent(address user, bool open) public returns (bool) {
+    function isSolvent(address user, bool open) public view returns (bool) {
         // accrue must have already been called!
         if (userBorrowShare[user] == 0) return true;
         if (totalCollateral == 0) return false;

--- a/contracts/libraries/BoringMath.sol
+++ b/contracts/libraries/BoringMath.sol
@@ -5,13 +5,14 @@ library BoringMath {
     function add(uint a, uint b) internal pure returns (uint c) {require((c = a + b) >= b, "BoringMath: Add Overflow");}
     function sub(uint a, uint b) internal pure returns (uint c) {require((c = a - b) <= a, "BoringMath: Underflow");}
     function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+    	// previous implementation:
+    	// require(a == 0 || (c = a * b)/b == a
+    	// was failing if b = 0
         if (a == 0) {
             return 0;
         }
-
         uint256 c = a * b;
         require(c / a == b, "BoringMath: Mul Overflow");
-
         return c;
     }
 }

--- a/contracts/libraries/BoringMath.sol
+++ b/contracts/libraries/BoringMath.sol
@@ -4,5 +4,14 @@ pragma solidity ^0.6.12;
 library BoringMath {
     function add(uint a, uint b) internal pure returns (uint c) {require((c = a + b) >= b, "BoringMath: Add Overflow");}
     function sub(uint a, uint b) internal pure returns (uint c) {require((c = a - b) <= a, "BoringMath: Underflow");}
-    function mul(uint a, uint b) internal pure returns (uint c) {require(a == 0 || (c = a * b)/b == a, "BoringMath: Mul Overflow");}
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "BoringMath: Mul Overflow");
+
+        return c;
+    }
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,6 +1,5 @@
 const BentoBox = artifacts.require("BentoBox");
 const Pair = artifacts.require("LendingPair");
-const WETH9 = artifacts.require("WETH9");
 const SushiSwapDelegateSwapper = artifacts.require("SushiSwapDelegateSwapper");
 const {e18} = require("../test/helpers/utils");
 
@@ -8,7 +7,6 @@ const {e18} = require("../test/helpers/utils");
 module.exports = async function (deployer, network, accounts) {
   await deployer.deploy(BentoBox, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
   await deployer.deploy(Pair);
-
 
   // Get the contracts
   let bentoBox = await BentoBox.deployed();

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,14 +1,14 @@
 const BentoBox = artifacts.require("BentoBox");
 const Pair = artifacts.require("LendingPair");
+const WETH9 = artifacts.require("WETH9");
 const SushiSwapDelegateSwapper = artifacts.require("SushiSwapDelegateSwapper");
+const {e18} = require("../test/helpers/utils");
 
-function e18(amount) {
-  return new web3.utils.BN(amount).mul(new web3.utils.BN("1000000000000000000"));
-}
 
 module.exports = async function (deployer, network, accounts) {
   await deployer.deploy(BentoBox, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
   await deployer.deploy(Pair);
+
 
   // Get the contracts
   let bentoBox = await BentoBox.deployed();

--- a/test/pair.js
+++ b/test/pair.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const truffleAssert = require('./helpers/truffle-assertions');
 const timeWarp = require("./helpers/timeWarp");
 const permit = require("./helpers/permit");
+const {e18} = require("./helpers/utils");
 const BentoBox = artifacts.require("BentoBox");
 const TokenA = artifacts.require("TokenA");
 const TokenB = artifacts.require("TokenB");
@@ -16,8 +17,9 @@ const testOracle = JSON.parse(fs.readFileSync("./build/contracts/TestOracle.json
 const {getInitData} = require("./helpers/getInitData");
 const {ecsign} = ethereumjsUtil;
 
-function e18(amount) {
-  return new web3.utils.BN(amount).mul(new web3.utils.BN("1000000000000000000"));
+function netBorrowFee(amount) {
+  const withDecimals = new web3.utils.BN(amount).mul(new web3.utils.BN("1000000000000000000"));
+  return withDecimals.mul(new web3.utils.BN("2000")).div(new web3.utils.BN("2001"));
 }
 
 async function logStatus(bentoBox, pair, a, b, alice, bob) {
@@ -182,7 +184,7 @@ contract('LendingPair', (accounts) => {
   })
 
   it('should allow borrowing with collateral up to 75%', async () => {
-    await pair.borrow(e18(75), alice, { from: alice });
+    await pair.borrow(netBorrowFee(75), alice, { from: alice });
   });
 
   it('should not allow any more borrowing', async () => {

--- a/test/short.js
+++ b/test/short.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const truffleAssert = require('./helpers/truffle-assertions');
 const timeWarp = require("./helpers/timeWarp");
-
+const {e18} = require('./helpers/utils');
 const BentoBox = artifacts.require("BentoBox");
 const TokenA = artifacts.require("TokenA");
 const TokenB = artifacts.require("TokenB");
@@ -14,15 +14,13 @@ const lendingPair = JSON.parse(fs.readFileSync("./build/contracts/LendingPair.js
 const testOracle = JSON.parse(fs.readFileSync("./build/contracts/TestOracle.json", "utf8"));
 const {getInitData} = require("./helpers/getInitData");
 
-function e18(amount) {
-  return new web3.utils.BN(amount).mul(new web3.utils.BN("1000000000000000000"));
-}
 
 contract('Pair (Shorting)', (accounts) => {
   let a;
   let b;
   let pair_address;
   let pair;
+  let sushiswappair;
   let bentoBox;
   let bentoFactory;
   let swapper;
@@ -42,7 +40,7 @@ contract('Pair (Shorting)', (accounts) => {
     await pairMaster.setSwapper(swapper.address, true);
 
     let tx = await factory.createPair(a.address, b.address);
-    let sushiswappair = await UniswapV2Pair.at(tx.logs[0].args.pair);
+    sushiswappair = await UniswapV2Pair.at(tx.logs[0].args.pair);
     await a.transfer(sushiswappair.address, e18("5000"));
     await b.transfer(sushiswappair.address, e18("5000"));
     await sushiswappair.mint(accounts[0]);
@@ -80,17 +78,57 @@ contract('Pair (Shorting)', (accounts) => {
     await truffleAssert.reverts(pair.short(swapper.address, e18(300), e18(200), { from: alice }), 'BentoBox: user insolvent');
   });
 
+  it('should have correct balances before short', async () => {
+    assert.equal((await pair.userCollateral(alice)).toString(), e18(100).toString());
+    assert.equal((await pair.balanceOf(alice)).toString(), "0");
+    assert.equal((await pair.userBorrowShare(alice)).toString(), "0");
+    assert.equal((await pair.balanceOf(bob)).toString(), e18(1000).toString());
+    assert.equal((await pair.totalSupply()).toString(), e18(1000).toString());
+    assert.equal((await pair.totalAsset()).toString(), e18(1000).toString());
+    assert.equal((await pair.totalBorrow()).toString(), "0");
+    assert.equal((await pair.totalBorrowShare()).toString(), "0");
+    assert.equal((await bentoBox.shareOf(a.address, pair.address)).toString(), e18(100).toString());
+    assert.equal((await bentoBox.shareOf(b.address, pair.address)).toString(), e18(1000).toString());
+    assert.equal((await bentoBox.totalShare(a.address)).toString(), e18(100).toString());
+    assert.equal((await bentoBox.totalBalance(a.address)).toString(), e18(100).toString());
+    assert.equal((await bentoBox.totalShare(b.address)).toString(), e18(1000).toString());
+    assert.equal((await bentoBox.totalBalance(b.address)).toString(), e18(1000).toString());
+  })
+
   it('should allow shorting', async () => {
     await pair.short(swapper.address, e18(250), e18(230), { from: alice });
   });
 
   it('should have correct balances after short', async () => {
+    // check distribution of collateral (tokenA)
+    assert.equal((await a.balanceOf(sushiswappair.address)).toString(), "4762585131209220364815");
+    assert.equal((await a.balanceOf(bentoBox.address)).toString(), "337414868790779635185");
+    assert.equal((await bentoBox.totalShare(a.address)).toString(), e18(100).toString()); // !!! should be 337
+    assert.equal((await bentoBox.totalBalance(a.address)).toString(), e18(100).toString()); // !!! should be 337
+    assert.equal((await bentoBox.shareOf(a.address, pair.address)).toString(), "337414868790779635185");
     assert.equal((await pair.userCollateral(alice)).toString(), "337414868790779635185");
+
+    // check distribution of asset/borrow (tokenB)
+    assert.equal((await b.balanceOf(sushiswappair.address)).toString(), "5250000000000000000000");
+    assert.equal((await b.balanceOf(bentoBox.address)).toString(), "750000000000000000000");
+    assert.equal((await b.balanceOf(alice)).toString(), "0"); // !!! should be 75
+    assert.equal((await bentoBox.totalShare(b.address)).toString(), e18(1000).toString());
+    assert.equal((await bentoBox.totalBalance(b.address)).toString(), e18(1000).toString());
+    assert.equal((await bentoBox.shareOf(b.address, pair.address)).toString(), e18(1000).toString());  // !!! should be 750
+    assert.equal((await pair.totalSupply()).toString(), e18(1000).toString());  // !!! should be 750
+    assert.equal((await pair.totalAsset()).toString(), e18(1000).toString()); // !!! should be 500
+    assert.equal((await pair.totalBorrow()).toString(), e18(250).toString());
+    assert.equal((await pair.totalBorrowShare()).toString(), e18(250).toString());
     assert.equal((await pair.balanceOf(alice)).toString(), "0");
-    assert.equal((await pair.userBorrowShare(alice)).toString(), "250000000000000000000");
-  })
+    assert.equal((await pair.balanceOf(bob)).toString(), e18(1000).toString());  // !!! should be 500
+    assert.equal((await pair.userBorrowShare(alice)).toString(), e18(250).toString());
+  });
 
   it('should allow unwinding the short', async () => {
-    await pair.unwind(swapper.address, e18(250), e18(337), { from: alice });
+    const tx = await pair.unwind(swapper.address, e18(250), e18(337), { from: alice });
+    console.log(tx.receipt.rawLogs);
+    console.log(tx.receipt.logs[3].args.amountFromMax.toString());
+    console.log(tx.receipt.logs[3].args.exactAmountTo.toString());
+    console.log(tx.receipt.logs[3].args.bla);
   });
 });


### PR DESCRIPTION
trying to fix failing test:
```
  1) Contract: Pair (Shorting)
       should allow unwinding the short:
     Error: Returned error: VM Exception while processing transaction: revert BentoBox: Swap failed -- Reason given: BentoBox: Swap failed.
```

i'm observing:
- wrong internal balances in BentoBox and Pair, marked with `!!!` in tests.
- BorringMath underflow in DelegateSwapper