### PR TITLE
save 1 storage slots

### DIFF
--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -6,6 +6,7 @@ pragma solidity 0.6.12;
 
 // Data part taken out for building of contracts that receive delegate calls
 contract ERC20Data {
+    uint256 public totalSupply;
     mapping(address => uint256) public balanceOf;
     mapping(address => mapping (address => uint256)) allowance;
     mapping(address => uint256) public nonces;

--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -6,7 +6,6 @@ pragma solidity 0.6.12;
 
 // Data part taken out for building of contracts that receive delegate calls
 contract ERC20Data {
-    uint256 public totalSupply;
     mapping(address => uint256) public balanceOf;
     mapping(address => mapping (address => uint256)) allowance;
     mapping(address => uint256) public nonces;

--- a/contracts/LendingPair.sol
+++ b/contracts/LendingPair.sol
@@ -182,7 +182,9 @@ contract LendingPair is ERC20, Ownable, IMasterContract {
 
     function getAssetBalance(address user) external view returns (uint256) {
         if (totalSupply == 0) {return 0;}
-        uint256 boxShare = balanceOf[user].mul(bentoBox.shareOf(asset, address(this))) / totalSupply;
+        uint256 remainingBoxShare = bentoBox.shareOf(asset, address(this));
+        uint256 totalBoxShare = remainingBoxShare.mul(totalAssetShare) / totalAssetShare.sub(totalBorrowShare);
+        uint256 boxShare = balanceOf[user].mul(totalBoxShare) / totalSupply;
         return bentoBox.toAmount(asset, boxShare);
     }
 
@@ -283,6 +285,23 @@ contract LendingPair is ERC20, Ownable, IMasterContract {
         // Subtracts the calculated fraction from the total of supply   
         totalSupply = totalSupply.sub(fraction);
     }
+
+    // Handles internal variable updates when supply is withdrawn and returns the amount of supply withdrawn
+    // function _removeAssetFraction(address user, uint256 fraction) private returns (uint256 boxShare) {
+    //     // Subtracts the fraction from user
+    //     balanceOf[user] = balanceOf[user].sub(fraction);
+
+    //     // Subtracts the share from the total of supply shares
+    //     uint256 assetShare = fraction.mul(totalAssetShare) / totalSupply;
+    //     totalAssetShare = totalAssetShare.sub(assetShare);
+    //     emit RemoveAsset(msg.sender, assetShare, fraction);
+
+    //     // Calculates the share of tokens to withdraw
+    //     boxShare = fraction.mul(bentoBox.shareOf(asset, address(this))) / totalSupply;
+
+    //     // Subtracts the calculated fraction from the total of supply   
+    //     totalSupply = totalSupply.sub(fraction);
+    // }
 
     // Handles internal variable updates when supply is repaid
     function _removeBorrowFraction(address user, uint256 fraction) private returns (uint256 share) {

--- a/contracts/LendingPair.sol
+++ b/contracts/LendingPair.sol
@@ -275,34 +275,20 @@ contract LendingPair is ERC20, Ownable, IMasterContract {
         // Subtracts the fraction from user
         balanceOf[user] = balanceOf[user].sub(fraction);
 
+        uint256 remainingBoxShare = bentoBox.shareOf(asset, address(this));
+        uint256 totalBoxShare = remainingBoxShare.mul(totalAssetShare) / totalAssetShare.sub(totalBorrowShare);
+
         // Subtracts the share from the total of supply shares
         uint256 assetShare = fraction.mul(totalAssetShare) / totalSupply;
         totalAssetShare = totalAssetShare.sub(assetShare);
-        emit RemoveAsset(msg.sender, assetShare, fraction);
+        emit RemoveAsset(msg.sender, fraction, assetShare);
 
         // Calculates the share of tokens to withdraw
-        boxShare = fraction.mul(bentoBox.shareOf(asset, address(this))) / totalSupply;
+        boxShare = fraction.mul(totalBoxShare) / totalSupply;
 
         // Subtracts the calculated fraction from the total of supply   
         totalSupply = totalSupply.sub(fraction);
     }
-
-    // Handles internal variable updates when supply is withdrawn and returns the amount of supply withdrawn
-    // function _removeAssetFraction(address user, uint256 fraction) private returns (uint256 boxShare) {
-    //     // Subtracts the fraction from user
-    //     balanceOf[user] = balanceOf[user].sub(fraction);
-
-    //     // Subtracts the share from the total of supply shares
-    //     uint256 assetShare = fraction.mul(totalAssetShare) / totalSupply;
-    //     totalAssetShare = totalAssetShare.sub(assetShare);
-    //     emit RemoveAsset(msg.sender, assetShare, fraction);
-
-    //     // Calculates the share of tokens to withdraw
-    //     boxShare = fraction.mul(bentoBox.shareOf(asset, address(this))) / totalSupply;
-
-    //     // Subtracts the calculated fraction from the total of supply   
-    //     totalSupply = totalSupply.sub(fraction);
-    // }
 
     // Handles internal variable updates when supply is repaid
     function _removeBorrowFraction(address user, uint256 fraction) private returns (uint256 share) {

--- a/contracts/LendingPair.sol
+++ b/contracts/LendingPair.sol
@@ -134,12 +134,15 @@ contract LendingPair is ERC20, Ownable, IMasterContract {
             // or a contract destructs itself and send the remains to this address
 
         // swipe token
-        IERC20 token = IERC20(token);
         token.transfer(owner, token.balanceOf(address(this)));
         
         // swipe excess box balance
-            // we use share as totalSupply, so there can never be excessive supply
+        if (token != asset && token != collateral) {
+            bentoBox.transferShare(token, owner, bentoBox.shareOf(token, address(this)));
+        } else {
+            // asset and collateral can not have excessive box balances
             // if some-one deposits into BentoBox giving the Pair as "to", then funds are shared among all LPs
+        }
     }
 
     function setFeeTo(address newFeeTo) public onlyOwner { feeTo = newFeeTo; }

--- a/contracts/LendingPair.sol
+++ b/contracts/LendingPair.sol
@@ -180,16 +180,16 @@ contract LendingPair is ERC20, Ownable, IMasterContract {
         return bentoBox.shareOf(collateral, address(this));
     }
 
-    function getAssetBalance() external view returns (uint256) {
+    function getAssetBalance(address user) external view returns (uint256) {
         if (totalSupply == 0) {return 0;}
-        uint256 boxShare = balanceOf[msg.sender].mul(bentoBox.shareOf(asset, address(this))) / totalSupply;
+        uint256 boxShare = balanceOf[user].mul(bentoBox.shareOf(asset, address(this))) / totalSupply;
         return bentoBox.toAmount(asset, boxShare);
     }
 
-    function getCollateralBalance() external view returns (uint256) {
+    function getCollateralBalance(address user) external view returns (uint256) {
         uint256 totalCollateralShare = bentoBox.shareOf(collateral, address(this));
         if (totalCollateralShare == 0) {return 0;}
-        uint256 boxShare = userCollateralShare[msg.sender].mul(1e18) / totalCollateralShare;
+        uint256 boxShare = userCollateralShare[user].mul(1e18) / totalCollateralShare;
         return bentoBox.toAmount(asset, boxShare);
     }
 
@@ -237,11 +237,11 @@ contract LendingPair is ERC20, Ownable, IMasterContract {
         uint256 newFraction = totalSupply == 0 ? boxShare : boxShare.mul(totalSupply) / boxTotalBefore;
         // Adds this share to user
         balanceOf[user] = balanceOf[user].add(newFraction);
-        // Adds this share to the total of supply shares    
+        // Adds this share to the total of supply shares
         totalSupply = totalSupply.add(newFraction);
         
         // uint256 assetShare = totalAssetShare == 0 ? newFraction : newFraction.mul(totalAssetShare) / totalSupply;
-        // new don't get afraction of assetShare, as new investors' capical hasn't had time to work yet
+        // new investors don't get a fraction of assetShare, as their capical hasn't had time to work yet
         // Adds the amount deposited to the total of supply
         totalAssetShare = totalAssetShare.add(newFraction);
         emit AddAsset(msg.sender, newFraction, newFraction);

--- a/test/pair.js
+++ b/test/pair.js
@@ -243,7 +243,45 @@ contract('LendingPair', (accounts) => {
     await pair.removeCollateral(shareALeft, alice, { from: alice });
   });
 
+  it('should allow full withdrawal of asset', async () => {
+    let bb = await pair.balanceOf(bob);
+    await pair.removeAsset(bb, bob, { from: bob });
+  });
+  
+  it('deposits to pair through bento should be split over LPs', async () => {
+    
+    // make propper deposit of 300
+    await b.approve(bentoBox.address, e18(300), { from: alice });
+    await pair.addAsset(e18(300), { from: alice });
+    // make propper deposit of 300
+    await b.approve(bentoBox.address, e18(300), { from: bob });
+    await pair.addAsset(e18(300), { from: bob });
+
+    // make rogue deposit of 300
+    await b.approve(bentoBox.address, e18(300), { from: bob });
+    await bentoBox.depositTo(b.address, bob, pair.address, e18(300), {from: bob});
+
+    // check
+    let balance = await pair.getAssetBalance(bob);
+    assert.equal(balance.toString(), e18(450).toString());
+
+    // withdraw 450
+    balance = await pair.balanceOf(alice);
+    await pair.removeAsset(balance, alice, { from: alice });
+
+    // withdraw 450
+    balance = await pair.balanceOf(bob);
+    await pair.removeAsset(balance, bob, { from: bob });
+
+    balance = await b.balanceOf(bentoBox.address);
+    assert.equal(balance.toString(), "0");
+  });
+
   it('should update the interest rate according to utilization', async () => {
+    // make propper deposit of 300
+    await b.approve(bentoBox.address, e18(300), { from: alice });
+    await pair.addAsset(e18(300), { from: alice });
+    
     // run for a while with 0 utilization
     let rate1 = await pair.interestPerBlock();
     for (let i = 0; i < 20; i++) {
@@ -270,40 +308,6 @@ contract('LendingPair', (accounts) => {
     await pair.accrue({ from: alice });
     rate2 = await pair.interestPerBlock();
     assert(rate2.gt(rate1), "rate has not adjusted up with high utilization");
-  });
-
-  it('should allow full withdrawal of asset', async () => {
-    let bb = await pair.balanceOf(bob);
-    await pair.removeAsset(bb, bob, { from: bob });
-  });
-
-  it('deposits to pair through bento should be split over LPs', async () => {
-    // make propper deposit of 300
-    await b.approve(bentoBox.address, e18(300), { from: alice });
-    await pair.addAsset(e18(300), { from: alice });
-    // make propper deposit of 300
-    await b.approve(bentoBox.address, e18(300), { from: bob });
-    await pair.addAsset(e18(300), { from: bob });
-
-    // make rogue deposit of 300
-    await b.approve(bentoBox.address, e18(300), { from: bob });
-    await bentoBox.depositTo(b.address, bob, pair.address, e18(300), {from: bob});
-
-    // check
-    let balance = await pair.getAssetBalance(bob);
-    assert.equal(balance.toString(), e18(450).toString());
-
-
-    // withdraw 450
-    balance = await pair.balanceOf(alice);
-    await pair.removeAsset(balance, alice, { from: alice });
-
-    // withdraw 450
-    balance = await pair.balanceOf(bob);
-    await pair.removeAsset(balance, bob, { from: bob });
-
-    balance = await b.balanceOf(bentoBox.address);
-    assert.equal(balance.toString(), "0");
   });
 
 });

--- a/test/pair.js
+++ b/test/pair.js
@@ -290,7 +290,7 @@ contract('LendingPair', (accounts) => {
     await bentoBox.depositTo(b.address, bob, pair.address, e18(300), {from: bob});
 
     // check
-    let balance = await pair.getAssetBalance({from: bob});
+    let balance = await pair.getAssetBalance(bob);
     assert.equal(balance.toString(), e18(450).toString());
 
 
@@ -302,7 +302,7 @@ contract('LendingPair', (accounts) => {
     balance = await pair.balanceOf(bob);
     await pair.removeAsset(balance, bob, { from: bob });
 
-    balance = await b.balanceOf(bentoBox.address, {from: bob});
+    balance = await b.balanceOf(bentoBox.address);
     assert.equal(balance.toString(), "0");
   });
 


### PR DESCRIPTION
observation: `share` does not necessarily reference the same total in Box vs Pair.

so:
- avoid `share / totalAssetShare`
- calculate separate `assetShare` and `boxShare`
- `boxShare` based on:
   ```
   boxSharesRemaining        totalAssetShare - totalBorrowedShare    
   ---------------------  =  ---------------------------------------
       totalBoxShares                 totalAssetShare
   ```

=> **rogue deposits** won't be lost any more, but split between LPs.