### PR TITLE
remove priceAverage - WIP

### DIFF
--- a/contracts/oracles/SimpleSLPTWAP1Oracle.sol
+++ b/contracts/oracles/SimpleSLPTWAP1Oracle.sol
@@ -15,12 +15,12 @@ import "../libraries/FixedPoint.sol";
 contract SimpleSLPTWAP1Oracle is IOracle {
     using FixedPoint for *;
     using BoringMath for uint256;
-    uint256 public constant PERIOD = 5 minutes;
+    uint256 public constant PERIOD = 20;
 
     struct PairInfo {
         uint256 priceCumulativeLast;
+        uint32 blockHeightLast;
         uint32 blockTimestampLast;
-        FixedPoint.uq112x112 priceAverage;
     }
 
     mapping(IUniswapV2Pair => PairInfo) public pairs; // Map of pairs and their info
@@ -42,45 +42,50 @@ contract SimpleSLPTWAP1Oracle is IOracle {
 
     function getDataParameter(IUniswapV2Pair pair) public pure returns (bytes memory) { return abi.encode(pair); }
 
+    event Data(uint256 a, uint256 b, uint256 c);
+
     // Get the latest exchange rate, if no valid (recent) rate is available, return false
     function get(bytes calldata data) external override returns (bool, uint256) {
         IUniswapV2Pair pair = abi.decode(data, (IUniswapV2Pair));
+        PairInfo memory pairInfo = pairs[pair];
         uint32 blockTimestamp = uint32(block.timestamp % 2 ** 32);
-        if (pairs[pair].blockTimestampLast == 0) {
-            pairs[pair].blockTimestampLast = blockTimestamp;
-            pairs[pair].priceCumulativeLast = _get(pair, blockTimestamp);
+        if (pairInfo.blockTimestampLast == 0) {
+            pairs[pair] = PairInfo(_get(pair, blockTimestamp), uint32(block.number), blockTimestamp);
             return (false, 0);
         }
-        uint32 timeElapsed = blockTimestamp - pairs[pair].blockTimestampLast; // overflow is desired
-        if (timeElapsed < PERIOD) {
-            return (true, pairs[pair].priceAverage.mul(10**18).decode144());
+        
+        if (block.number.sub(pairInfo.blockHeightLast) < PERIOD) {
+            return (false, 0);
         }
 
         uint256 priceCumulative = _get(pair, blockTimestamp);
-        pairs[pair].priceAverage = FixedPoint.uq112x112(uint224((priceCumulative - pairs[pair].priceCumulativeLast) / timeElapsed));
-        pairs[pair].blockTimestampLast = blockTimestamp;
-        pairs[pair].priceCumulativeLast = priceCumulative;
+        uint32 timeElapsed = blockTimestamp - pairInfo.blockTimestampLast; // substraction overflow is desired
+        FixedPoint.uq112x112 memory priceAverage = FixedPoint.uq112x112(uint224((priceCumulative - pairInfo.priceCumulativeLast) / timeElapsed));
+        pairs[pair] = PairInfo(priceCumulative, uint32(block.number), blockTimestamp);
 
-        return (true, pairs[pair].priceAverage.mul(10**18).decode144());
+        emit Data(priceCumulative, pairInfo.priceCumulativeLast, priceAverage.mul(10**18).decode144());
+        return (true, priceAverage.mul(10**18).decode144());
     }
 
     // Check the last exchange rate without any state changes
     function peek(bytes calldata data) public override view returns (bool, uint256) {
         IUniswapV2Pair pair = abi.decode(data, (IUniswapV2Pair));
+        PairInfo memory pairInfo = pairs[pair];
         uint32 blockTimestamp = uint32(block.timestamp % 2 ** 32);
-        if (pairs[pair].blockTimestampLast == 0) {
+        if (pairInfo.blockTimestampLast == 0 || blockTimestamp == pairInfo.blockTimestampLast) {
             return (false, 0);
         }
-        uint32 timeElapsed = blockTimestamp - pairs[pair].blockTimestampLast; // overflow is desired
-        if (timeElapsed < PERIOD) {
-            return (true, pairs[pair].priceAverage.mul(10**18).decode144());
+    
+        bool available = true;
+        if (block.number.sub(pairInfo.blockHeightLast) < PERIOD) {
+            available = false;
         }
 
         uint256 priceCumulative = _get(pair, blockTimestamp);
+        uint32 timeElapsed = blockTimestamp - pairInfo.blockTimestampLast; // overflow is desired
         FixedPoint.uq112x112 memory priceAverage = FixedPoint
-            .uq112x112(uint224((priceCumulative - pairs[pair].priceCumulativeLast) / timeElapsed));
-
-        return (true, priceAverage.mul(10**18).decode144());
+            .uq112x112(uint224((priceCumulative - pairInfo.priceCumulativeLast) / timeElapsed));
+        return (available, priceAverage.mul(10**18).decode144());
     }
 
     function name(bytes calldata) public override view returns (string memory) {

--- a/test/helpers/timeWarp.js
+++ b/test/helpers/timeWarp.js
@@ -34,8 +34,17 @@ advanceBlock = () => {
     });
 }
 
+advanceBlocks = async (number) => {
+    while (number > 1) {
+        await advanceBlock();
+        number--;
+    }
+    return advanceBlock();
+}
+
 module.exports = {
     advanceTime,
     advanceBlock,
+    advanceBlocks,
     advanceTimeAndBlock
 }

--- a/test/simpleSLPOracle.js
+++ b/test/simpleSLPOracle.js
@@ -56,23 +56,25 @@ contract('SimpleSLPOracle', (accounts) => {
   });
 
   it('should return false on first peek', async () => {
-    assert.equal((await oracle.peek(oracleData))[1].toString(),"0", "without initialization the oracle should have a zero price");
+    const result = await oracle.peek(oracleData);
+    assert.equal((result)[1].toString(),"0", "without initialization the oracle should have a zero price");
   });
 
   it('should update and get prices within period', async () => {
     const blockTimestamp = (await pair.getReserves())[2];
 
     await oracle.get(oracleData);
+    await timeWarp.advanceBlocks(5);
     await timeWarp.advanceTime(30);
     await oracle.get(oracleData);
+    await timeWarp.advanceBlocks(16);
     await timeWarp.advanceTime(271);
-    //await oracle.get(oracleData);
     await oracle.get(oracleData);
+    // for coverage
     await oracle.get(oracleData);
 
-    const expectedPrice = encodePrice(token0Amount, token1Amount);
-    assert.equal((await oracle.pairs(pair.address)).priceAverage.toString(), expectedPrice[1].toString());
-    assert.equal((await oracle.peek(oracleData))[1].toString(), e18(1).mul(new web3.utils.BN(5)).div(new web3.utils.BN(10)).toString(), "amount of collateral to buy 1e18 of assets");
+    const expectedPrice = e18(1).mul(new web3.utils.BN(5)).div(new web3.utils.BN(10));
+    assert.equal((await oracle.peek(oracleData))[1].toString(), expectedPrice.toString(), "amount of collateral to buy 1e18 of assets");
   });
 
   it('should get prices if Period time is over', async () => {
@@ -80,15 +82,16 @@ contract('SimpleSLPOracle', (accounts) => {
 
     await oracle.get(oracleData);
     await timeWarp.advanceTime(30);
+    await timeWarp.advanceBlocks(5);
     await oracle.get(oracleData);
     await timeWarp.advanceTime(271);
-    //await oracle.get(oracleData);
+    await timeWarp.advanceBlocks(15);
     await oracle.get(oracleData);
+    await timeWarp.advanceBlocks(25);
     await timeWarp.advanceTime(421);
 
-    const expectedPrice = encodePrice(token0Amount, token1Amount);
-    assert.equal((await oracle.pairs(pair.address)).priceAverage.toString(), expectedPrice[1].toString());
-    assert.equal((await oracle.peek(oracleData))[1].toString(), e18(1).mul(new web3.utils.BN(5)).div(new web3.utils.BN(10)).toString(), "amount of collateral to buy 1e18 of assets");
+    const expectedPrice = e18(1).mul(new web3.utils.BN(5)).div(new web3.utils.BN(10));
+    assert.equal((await oracle.peek(oracleData))[1].toString(), expectedPrice.toString(), "amount of collateral to buy 1e18 of assets");
   });
 
 
@@ -96,12 +99,15 @@ contract('SimpleSLPOracle', (accounts) => {
     const blockTimestamp = (await pair.getReserves())[2];
     await oracle.get(oracleData);
     await timeWarp.advanceTime(301);
+    await timeWarp.advanceBlocks(20);
     await oracle.get(oracleData);
     let price0 = (await oracle.peek(oracleData))[1];
     await collateral.transfer(pair.address, e18(5));
     await timeWarp.advanceTime(150);
+    await timeWarp.advanceBlocks(10);
     await pair.sync();
     await timeWarp.advanceTime(150);
+    await timeWarp.advanceBlocks(10);
     await oracle.get(oracleData);
     let price1 = (await oracle.peek(oracleData))[1];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3284,7 +3284,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*:
+mkdirp@*, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==


### PR DESCRIPTION
trying to remove the `priceAverage` in the storage leads to the following code:

```
        uint32 blockTimestamp = uint32(block.timestamp % 2 ** 32);
        if (pairInfo.blockTimestampLast == 0 || blockTimestamp == pairInfo.blockTimestampLast) {
            return (false, 0);
        }
    
        bool available = true;
        if (block.number.sub(pairInfo.blockHeightLast) < PERIOD) {
            available = false;
        }

       // calculate and return price
```

we return `available = false` when the oracle is called for the first time, or the update period has not passed yet. The consuming contract knows that the value can not be used, either it is not a full measurement, or a measurement over a too short time period, and hence attackable through market manipulation.

unfortunately the `get()` function is public, callable by any-one, leading to a scenario where the consuming contract can be deprived of price data by constantly frontrunning the `get()`.