### PR TITLE
Base strategy

### DIFF
--- a/contracts/interfaces/IBentoBoxMinimal.sol
+++ b/contracts/interfaces/IBentoBoxMinimal.sol
@@ -1,0 +1,84 @@
+pragma solidity 0.6.12;
+
+import "@boringcrypto/boring-solidity/contracts/libraries/BoringRebase.sol";
+
+/// @notice Minimal interface for BentoBox token vault interactions - `token` is aliased as `address` from `IERC20` for code simplicity.
+interface IBentoBoxMinimal {
+    /// @notice Balance per ERC-20 token per account in shares.
+    function balanceOf(address, address) external view returns (uint256);
+
+    /// @notice Deposit an amount of `token` represented in either `amount` or `share`.
+    /// @param token_ The ERC-20 token to deposit.
+    /// @param from which account to pull the tokens.
+    /// @param to which account to push the tokens.
+    /// @param amount Token amount in native representation to deposit.
+    /// @param share Token amount represented in shares to deposit. Takes precedence over `amount`.
+    /// @return amountOut The amount deposited.
+    /// @return shareOut The deposited amount repesented in shares.
+    function deposit(
+        address token_,
+        address from,
+        address to,
+        uint256 amount,
+        uint256 share
+    ) external payable returns (uint256 amountOut, uint256 shareOut);
+
+    /// @notice Withdraws an amount of `token` from a user account.
+    /// @param token_ The ERC-20 token to withdraw.
+    /// @param from which user to pull the tokens.
+    /// @param to which user to push the tokens.
+    /// @param amount of tokens. Either one of `amount` or `share` needs to be supplied.
+    /// @param share Like above, but `share` takes precedence over `amount`.
+    function withdraw(
+        address token_,
+        address from,
+        address to,
+        uint256 amount,
+        uint256 share
+    ) external returns (uint256 amountOut, uint256 shareOut);
+
+    /// @notice Transfer shares from a user account to another one.
+    /// @param token The ERC-20 token to transfer.
+    /// @param from which user to pull the tokens.
+    /// @param to which user to push the tokens.
+    /// @param share The amount of `token` in shares.
+    function transfer(
+        address token,
+        address from,
+        address to,
+        uint256 share
+    ) external;
+
+    /// @dev Helper function to represent an `amount` of `token` in shares.
+    /// @param token The ERC-20 token.
+    /// @param amount The `token` amount.
+    /// @param roundUp If the result `share` should be rounded up.
+    /// @return share The token amount represented in shares.
+    function toShare(
+        address token,
+        uint256 amount,
+        bool roundUp
+    ) external view returns (uint256 share);
+
+    /// @dev Helper function to represent shares back into the `token` amount.
+    /// @param token The ERC-20 token.
+    /// @param share The amount of shares.
+    /// @param roundUp If the result should be rounded up.
+    /// @return amount The share amount back into native representation.
+    function toAmount(
+        address token,
+        uint256 share,
+        bool roundUp
+    ) external view returns (uint256 amount);
+
+    /// @notice Registers this contract so that users can approve it for the BentoBox.
+    function registerProtocol() external;
+    
+    function totals(address token) external view returns (Rebase memory);
+    
+    function harvest(
+        address token,
+        bool balance,
+        uint256 maxChangeAmount
+    ) external;
+}

--- a/contracts/interfaces/IBentoBoxMinimal.sol
+++ b/contracts/interfaces/IBentoBoxMinimal.sol
@@ -1,4 +1,7 @@
+// SPDX-License-Identifier: UNLICENSED
+
 pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
 
 import "@boringcrypto/boring-solidity/contracts/libraries/BoringRebase.sol";
 
@@ -73,9 +76,9 @@ interface IBentoBoxMinimal {
 
     /// @notice Registers this contract so that users can approve it for the BentoBox.
     function registerProtocol() external;
-    
+
     function totals(address token) external view returns (Rebase memory);
-    
+
     function harvest(
         address token,
         bool balance,

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -2,8 +2,7 @@
 pragma solidity 0.6.12;
 import "@boringcrypto/boring-solidity/contracts/ERC20.sol";
 
-contract ERC20Mock is ERC20 {
-    uint256 public totalSupply;
+contract ERC20Mock is ERC20WithSupply {
 
     constructor(uint256 _initialAmount) public {
         // Give the creator all initial tokens

--- a/contracts/mocks/SushiBarMock.sol
+++ b/contracts/mocks/SushiBarMock.sol
@@ -10,7 +10,7 @@ import "@boringcrypto/boring-solidity/contracts/libraries/BoringMath.sol";
 contract SushiBarMock is ERC20 {
     using BoringMath for uint256;
     ERC20 public sushi;
-    uint256 public totalSupply;
+    uint256 public override totalSupply;
     string public constant name = "SushiBar";
     string public constant symbol = "xSushi";
 

--- a/contracts/strategies/AaveStrategy.sol
+++ b/contracts/strategies/AaveStrategy.sol
@@ -1,0 +1,449 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "https://github.com/sushiswap/bentobox/blob/master/contracts/interfaces/IStrategy.sol";
+import "https://github.com/sushiswap/sushiswap/blob/MakerV3/contracts/uniswapv2/interfaces/IUniswapV2Factory.sol";
+import "https://github.com/sushiswap/sushiswap/blob/MakerV3/contracts/uniswapv2/interfaces/IUniswapV2Pair.sol";
+import "https://github.com/boringcrypto/BoringSolidity/blob/master/contracts/BoringOwnable.sol";
+import "https://github.com/boringcrypto/BoringSolidity/blob/master/contracts/libraries/BoringMath.sol";
+import "https://github.com/boringcrypto/BoringSolidity/blob/master/contracts/libraries/BoringERC20.sol";
+import "https://github.com/sushiswap/sushiswap/blob/MakerV3/contracts/uniswapv2/libraries/UniswapV2Library.sol";
+
+// solhint-disable avoid-low-level-calls
+// solhint-disable not-rely-on-time
+// solhint-disable no-empty-blocks
+// solhint-disable avoid-tx-origin
+
+library DataTypes {
+    struct ReserveData {
+        ReserveConfigurationMap configuration;
+        uint128 liquidityIndex;
+        uint128 variableBorrowIndex;
+        uint128 currentLiquidityRate;
+        uint128 currentVariableBorrowRate;
+        uint128 currentStableBorrowRate;
+        uint40 lastUpdateTimestamp;
+        address aTokenAddress;
+        address stableDebtTokenAddress;
+        address variableDebtTokenAddress;
+        address interestRateStrategyAddress;
+        uint8 id;
+    }
+    
+    struct ReserveConfigurationMap {
+        uint256 data;
+    }
+}
+
+interface IaToken {
+    function getReserveData(address asset) external view returns (DataTypes.ReserveData memory);
+    
+    function deposit( 
+        address asset, 
+        uint256 amount, 
+        address onBehalfOf, 
+        uint16 referralCode
+    ) external;
+
+    function withdraw( 
+        address token, 
+        uint256 amount, 
+        address destination
+    ) external;
+}
+
+interface IStakedAave {
+  function stake(address to, uint256 amount) external;
+
+  function redeem(address to, uint256 amount) external;
+
+  function cooldown() external;
+
+  function claimRewards(address to, uint256 amount) external;
+}
+
+// File @boringcrypto/boring-solidity/contracts/libraries/BoringRebase.sol@v1.2.0
+// License-Identifier: MIT
+
+struct Rebase {
+    uint128 elastic;
+    uint128 base;
+}
+
+/// @notice A rebasing library using overflow-/underflow-safe math.
+library RebaseLibrary {
+    using BoringMath for uint256;
+    using BoringMath128 for uint128;
+
+    /// @notice Calculates the base value in relationship to `elastic` and `total`.
+    function toBase(
+        Rebase memory total,
+        uint256 elastic,
+        bool roundUp
+    ) internal pure returns (uint256 base) {
+        if (total.elastic == 0) {
+            base = elastic;
+        } else {
+            base = elastic.mul(total.base) / total.elastic;
+            if (roundUp && base.mul(total.elastic) / total.base < elastic) {
+                base = base.add(1);
+            }
+        }
+    }
+
+    /// @notice Calculates the elastic value in relationship to `base` and `total`.
+    function toElastic(
+        Rebase memory total,
+        uint256 base,
+        bool roundUp
+    ) internal pure returns (uint256 elastic) {
+        if (total.base == 0) {
+            elastic = base;
+        } else {
+            elastic = base.mul(total.elastic) / total.base;
+            if (roundUp && elastic.mul(total.base) / total.elastic < base) {
+                elastic = elastic.add(1);
+            }
+        }
+    }
+
+    /// @notice Add `elastic` to `total` and doubles `total.base`.
+    /// @return (Rebase) The new total.
+    /// @return base in relationship to `elastic`.
+    function add(
+        Rebase memory total,
+        uint256 elastic,
+        bool roundUp
+    ) internal pure returns (Rebase memory, uint256 base) {
+        base = toBase(total, elastic, roundUp);
+        total.elastic = total.elastic.add(elastic.to128());
+        total.base = total.base.add(base.to128());
+        return (total, base);
+    }
+
+    /// @notice Sub `base` from `total` and update `total.elastic`.
+    /// @return (Rebase) The new total.
+    /// @return elastic in relationship to `base`.
+    function sub(
+        Rebase memory total,
+        uint256 base,
+        bool roundUp
+    ) internal pure returns (Rebase memory, uint256 elastic) {
+        elastic = toElastic(total, base, roundUp);
+        total.elastic = total.elastic.sub(elastic.to128());
+        total.base = total.base.sub(base.to128());
+        return (total, elastic);
+    }
+
+    /// @notice Add `elastic` and `base` to `total`.
+    function add(
+        Rebase memory total,
+        uint256 elastic,
+        uint256 base
+    ) internal pure returns (Rebase memory) {
+        total.elastic = total.elastic.add(elastic.to128());
+        total.base = total.base.add(base.to128());
+        return total;
+    }
+
+    /// @notice Subtract `elastic` and `base` to `total`.
+    function sub(
+        Rebase memory total,
+        uint256 elastic,
+        uint256 base
+    ) internal pure returns (Rebase memory) {
+        total.elastic = total.elastic.sub(elastic.to128());
+        total.base = total.base.sub(base.to128());
+        return total;
+    }
+
+    /// @notice Add `elastic` to `total` and update storage.
+    /// @return newElastic Returns updated `elastic`.
+    function addElastic(Rebase storage total, uint256 elastic) internal returns (uint256 newElastic) {
+        newElastic = total.elastic = total.elastic.add(elastic.to128());
+    }
+
+    /// @notice Subtract `elastic` from `total` and update storage.
+    /// @return newElastic Returns updated `elastic`.
+    function subElastic(Rebase storage total, uint256 elastic) internal returns (uint256 newElastic) {
+        newElastic = total.elastic = total.elastic.sub(elastic.to128());
+    }
+}
+
+/// @notice Minimal interface for BentoBox token vault interactions - `token` is aliased as `address` from `IERC20` for code simplicity.
+interface IBentoBoxMinimal {
+    /// @notice Balance per ERC-20 token per account in shares.
+    function balanceOf(address, address) external view returns (uint256);
+
+    /// @notice Deposit an amount of `token` represented in either `amount` or `share`.
+    /// @param token_ The ERC-20 token to deposit.
+    /// @param from which account to pull the tokens.
+    /// @param to which account to push the tokens.
+    /// @param amount Token amount in native representation to deposit.
+    /// @param share Token amount represented in shares to deposit. Takes precedence over `amount`.
+    /// @return amountOut The amount deposited.
+    /// @return shareOut The deposited amount repesented in shares.
+    function deposit(
+        address token_,
+        address from,
+        address to,
+        uint256 amount,
+        uint256 share
+    ) external payable returns (uint256 amountOut, uint256 shareOut);
+
+    /// @notice Withdraws an amount of `token` from a user account.
+    /// @param token_ The ERC-20 token to withdraw.
+    /// @param from which user to pull the tokens.
+    /// @param to which user to push the tokens.
+    /// @param amount of tokens. Either one of `amount` or `share` needs to be supplied.
+    /// @param share Like above, but `share` takes precedence over `amount`.
+    function withdraw(
+        address token_,
+        address from,
+        address to,
+        uint256 amount,
+        uint256 share
+    ) external returns (uint256 amountOut, uint256 shareOut);
+
+    /// @notice Transfer shares from a user account to another one.
+    /// @param token The ERC-20 token to transfer.
+    /// @param from which user to pull the tokens.
+    /// @param to which user to push the tokens.
+    /// @param share The amount of `token` in shares.
+    function transfer(
+        address token,
+        address from,
+        address to,
+        uint256 share
+    ) external;
+
+    /// @dev Helper function to represent an `amount` of `token` in shares.
+    /// @param token The ERC-20 token.
+    /// @param amount The `token` amount.
+    /// @param roundUp If the result `share` should be rounded up.
+    /// @return share The token amount represented in shares.
+    function toShare(
+        address token,
+        uint256 amount,
+        bool roundUp
+    ) external view returns (uint256 share);
+
+    /// @dev Helper function to represent shares back into the `token` amount.
+    /// @param token The ERC-20 token.
+    /// @param share The amount of shares.
+    /// @param roundUp If the result should be rounded up.
+    /// @return amount The share amount back into native representation.
+    function toAmount(
+        address token,
+        uint256 share,
+        bool roundUp
+    ) external view returns (uint256 amount);
+
+    /// @notice Registers this contract so that users can approve it for the BentoBox.
+    function registerProtocol() external;
+    
+    function totals(address token) external view returns (Rebase memory);
+    
+    function harvest(
+        address token,
+        bool balance,
+        uint256 maxChangeAmount
+    ) external;
+}
+
+interface IFactory {
+    function getPair(address tokenA, address tokenB) external view returns (address pair);
+}
+
+interface IPair {
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address owner) external view returns (uint256);
+
+    function token0() external view returns (address);
+
+    function token1() external view returns (address);
+
+    function getReserves()
+        external
+        view
+        returns (
+            uint112 reserve0,
+            uint112 reserve1,
+            uint32 blockTimestampLast
+        );
+
+    function swap(
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address to,
+        bytes calldata data
+    ) external;
+}
+
+contract AaveStrategy is IStrategy, BoringOwnable {
+    using BoringMath for uint256;
+    using BoringERC20 for IERC20;
+    using BoringERC20 for IaToken;
+    
+    address public immutable aave;
+    address public immutable aaveToken;
+    IBentoBoxMinimal public immutable bentobox;
+    address public immutable underlying;
+    bool public exited;
+    uint256 public maxShare;
+    
+    event LogConvert(
+        address indexed server,
+        address indexed token0,
+        address indexed token1,
+        uint256 amount0,
+        uint256 amount1
+    );
+
+    constructor(
+        address aave_,
+        IBentoBoxMinimal bentobox_,
+        address underlying_
+    ) public {
+        aave = aave_;
+        bentobox = bentobox_;
+        underlying = underlying_;
+        IERC20(underlying_).approve(aave_, type(uint256).max);
+        aaveToken = IaToken(aave_).getReserveData(underlying_).aTokenAddress;
+    }
+
+    modifier onlyBentobox {
+        // @dev Only the bentobox can call harvest on this strategy.
+        require(msg.sender == address(bentobox), "AaveStrategy: only bento");
+        require(!exited, "AaveStrategy: exited");
+        _;
+    }
+    
+    /// **** REWARD MGMT **** ///
+    function cooldown(IStakedAave stkAave) external {
+        stkAave.cooldown();
+    }
+    
+    function stake(IStakedAave stkAave, uint256 amount) external {
+        stkAave.stake(address(this), amount);
+    }
+    
+    function redeem(IStakedAave stkAave, uint256 amount) external {
+        stkAave.redeem(address(this), amount);
+    }
+    
+    function claimRewards(IStakedAave stkAave, uint256 amount) external {
+        stkAave.claimRewards(address(this), amount);
+    }
+    /// **** ///
+    
+    function preHarvest(uint256 maxBentoTokenShare, bool balance, uint256 maxChangeAmount) external onlyOwner {
+        maxShare = maxBentoTokenShare;
+        bentobox.harvest(underlying, balance, maxChangeAmount);
+    }
+
+    /// @notice Send the assets to the Strategy and call skim to invest them.
+    /// @inheritdoc IStrategy
+    function skim(uint256 amount) external override onlyBentobox {
+        IaToken(aave).deposit(underlying, amount, address(this), 0);
+    }
+
+    /// @notice Harvest any profits made converted to the asset and pass them to the caller.
+    /// @inheritdoc IStrategy
+    function harvest(uint256 balance, address sender) public override onlyBentobox returns (int256 amountAdded) {
+        // @dev To prevent anyone from using flash loans to 'steal' part of the profits, only EOA is allowed to call harvest.
+        require(sender == owner, "AaveStrategy: not owner"); // permission check
+        require(IBentoBoxMinimal(bentobox).totals(underlying).elastic <= maxShare, "AaveStrategy: mmm sandwiched"); // sandwich check
+        // @dev Get the amount of tokens that the aTokens currently represent.
+        uint256 tokenBalance = IERC20(underlying).safeBalanceOf(address(this));
+        // @dev Convert enough aToken to take out the profit.
+        // If the amount is negative due to rounding (near impossible), just revert (should be positive soon enough).
+        IaToken(aave).withdraw(underlying, tokenBalance.sub(balance), address(this));
+        uint256 amountAdded_ = IERC20(underlying).safeBalanceOf(address(this));
+        // @dev Transfer the profit to the bentobox, the amountAdded at this point matches the amount transferred.
+        IERC20(underlying).safeTransfer(address(bentobox), amountAdded_);
+        maxShare = 0; // nullify maxShare
+        return int256(amountAdded_);
+    }
+
+    /// @notice Withdraw assets.
+    /// @inheritdoc IStrategy
+    function withdraw(uint256 amount) external override onlyBentobox returns (uint256 actualAmount) {
+        // @dev Convert enough aToken to take out 'amount' tokens.
+        IaToken(aave).withdraw(underlying, amount, address(this));
+        // @dev Make sure we send and report the exact same amount of tokens by using balanceOf.
+        actualAmount = IERC20(underlying).safeBalanceOf(address(this));
+        IERC20(underlying).safeTransfer(address(bentobox), actualAmount);
+    }
+
+    /// @notice Withdraw all assets in the safest way possible - this shouldn't fail.
+    /// @inheritdoc IStrategy
+    function exit(uint256 balance) external override onlyBentobox returns (int256 amountAdded) {
+        // @dev Get the amount of tokens that the aTokens currently represent.
+        uint256 tokenBalance = IERC20(underlying).safeBalanceOf(address(this));
+        // @dev Get the actual token balance of the cToken contract.
+        uint256 available = IERC20(underlying).safeBalanceOf(underlying);
+        // @dev Check that the aToken contract has enough balance to pay out in full.
+        if (tokenBalance <= available) {
+            // @dev If there are more tokens available than our full position, take all based on aToken balance (continue if unsuccessful).
+            try IaToken(aave).withdraw(underlying, tokenBalance, address(this)) {} catch {}
+        } else {
+            // @dev Otherwise redeem all available and take a loss on the missing amount (continue if unsuccessful).
+            try IaToken(aave).withdraw(underlying, available, address(this)) {} catch {}
+        }
+        // @dev Check balance of token on the contract.
+        uint256 amount = IERC20(underlying).safeBalanceOf(address(this));
+        // @dev Calculate tokens added (or lost).
+        amountAdded = int256(amount) - int256(balance);
+        // @dev Transfer all tokens to bentobox.
+        IERC20(underlying).safeTransfer(address(bentobox), amount);
+        // @dev Flag as exited, allowing the owner to manually deal with any amounts available later.
+        exited = true;
+    }
+
+    function afterExit(
+        address to,
+        uint256 value,
+        bytes memory data
+    ) public onlyOwner returns (bool success) {
+        // @dev After exited, the owner can perform ANY call. This is to rescue any funds that didn't get released during exit or
+        // got earned afterwards due to vesting or airdrops, etc.
+        require(exited, "AaveStrategy: Not exited");
+        (success, ) = to.call{value: value}(data);
+    }
+    
+    // **** SWAP ****
+    // requires the initial amount to have already been sent to the first pair
+    function swapExactTokensForTokens(
+        uint256 amountOutMin,
+        address[] calldata path
+    ) public onlyOwner returns (uint[] memory amounts) {
+        amounts = UniswapV2Library.getAmountsOut(factory, IERC20(path[0]).safeBalanceOf(address(this)), path);
+        require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
+        IERC20(path[0]).safeTransfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
+        _swap(amounts, path, address(this));
+        emit LogConvert(
+            msg.sender,
+            path[0],
+            path[path.length - 1],
+            amountIn,
+            amounts[amounts.length - 1]
+        );
+    }
+    
+    function _swap(uint256[] memory amounts, address[] memory path, address _to) internal virtual {
+        for (uint i; i < path.length - 1; i++) {
+            (address input, address output) = (path[i], path[i + 1]);
+            (address token0,) = UniswapV2Library.sortTokens(input, output);
+            uint amountOut = amounts[i + 1];
+            (uint amount0Out, uint amount1Out) = input == token0 ? (uint(0), amountOut) : (amountOut, uint(0));
+            address to = i < path.length - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
+            IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output)).swap(
+                amount0Out, amount1Out, to, new bytes(0)
+            );
+        }
+    }
+}

--- a/contracts/strategies/AaveStrategy.sol
+++ b/contracts/strategies/AaveStrategy.sol
@@ -4,6 +4,7 @@ pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../interfaces/IStrategy.sol";
+import "../interfaces/IBentoBoxMinimal.sol";
 import "@boringcrypto/boring-solidity/contracts/BoringOwnable.sol";
 import "@boringcrypto/boring-solidity/contracts/libraries/BoringMath.sol";
 import "@boringcrypto/boring-solidity/contracts/libraries/BoringERC20.sol";
@@ -29,7 +30,7 @@ library DataTypes {
         address interestRateStrategyAddress;
         uint8 id;
     }
-    
+
     struct ReserveConfigurationMap {
         uint256 data;
     }
@@ -37,52 +38,45 @@ library DataTypes {
 
 interface IaToken {
     function getReserveData(address asset) external view returns (DataTypes.ReserveData memory);
-    
-    function deposit( 
-        address asset, 
-        uint256 amount, 
-        address onBehalfOf, 
+
+    function deposit(
+        address asset,
+        uint256 amount,
+        address onBehalfOf,
         uint16 referralCode
     ) external;
 
-    function withdraw( 
-        address token, 
-        uint256 amount, 
+    function withdraw(
+        address token,
+        uint256 amount,
         address destination
     ) external;
 }
 
 interface IStakedAave {
-  function stake(address to, uint256 amount) external;
+    function stake(address to, uint256 amount) external;
 
-  function redeem(address to, uint256 amount) external;
+    function redeem(address to, uint256 amount) external;
 
-  function cooldown() external;
+    function cooldown() external;
 
-  function claimRewards(address to, uint256 amount) external;
+    function claimRewards(address to, uint256 amount) external;
 }
-
 
 contract AaveStrategy is IStrategy, BoringOwnable {
     using BoringMath for uint256;
     using BoringERC20 for IERC20;
     using BoringERC20 for IaToken;
-    
+
     address public immutable aave;
     address public immutable aToken;
     IBentoBoxMinimal public immutable bentobox;
     address public immutable factory;
     address public immutable underlying;
     bool public exited;
-    uint256 public maxShare;
-    
-    event LogConvert(
-        address indexed server,
-        address indexed token0,
-        address indexed token1,
-        uint256 amount0,
-        uint256 amount1
-    );
+    uint256 public maxBentoBalance;
+
+    event LogConvert(address indexed server, address indexed token0, address indexed token1, uint256 amount0, uint256 amount1);
 
     constructor(
         address aave_,
@@ -104,23 +98,24 @@ contract AaveStrategy is IStrategy, BoringOwnable {
         require(!exited, "AaveStrategy: exited");
         _;
     }
-    
+
     /// **** REWARD MGMT **** ///
     function cooldown(IStakedAave stkAave) external {
         stkAave.cooldown();
     }
-    
+
     function stake(IStakedAave stkAave, uint256 amount) external {
         stkAave.stake(address(this), amount);
     }
-    
+
     function redeem(IStakedAave stkAave, uint256 amount) external {
         stkAave.redeem(address(this), amount);
     }
-    
+
     function claimRewards(IStakedAave stkAave, uint256 amount) external {
         stkAave.claimRewards(address(this), amount);
     }
+
     /// **** ///
 
     /// @notice Send the assets to the Strategy and call skim to invest them.
@@ -128,27 +123,34 @@ contract AaveStrategy is IStrategy, BoringOwnable {
     function skim(uint256 amount) external override onlyBentobox {
         IaToken(aave).deposit(underlying, amount, address(this), 0);
     }
-    
-    function safeHarvest(uint256 maxBentoTokenShare, bool rebalance, uint256 maxChangeAmount) external onlyOwner {
-        maxShare = maxBentoTokenShare;
+
+    function safeHarvest(
+        uint256 maxBentoTokenShare,
+        bool rebalance,
+        uint256 maxChangeAmount
+    ) external onlyOwner {
+        maxBentoBalance = maxBentoTokenShare;
         bentobox.harvest(underlying, rebalance, maxChangeAmount);
     }
 
     /// @notice Harvest any profits made converted to the asset and pass them to the caller.
     /// @inheritdoc IStrategy
     function harvest(uint256 balance, address sender) public override onlyBentobox returns (int256 amountAdded) {
-        require(sender == address(this), "AaveStrategy: wrong sender"); // permission check
-        require(IBentoBoxMinimal(bentobox).totals(underlying).elastic <= maxShare, "AaveStrategy: sandwiched"); // sandwich check
-        // @dev Get the amount of tokens that the aTokens currently represent.
-        uint256 tokenBalance = IERC20(aToken).safeBalanceOf(address(this));
-        // @dev Convert enough aToken to take out the profit.
-        // If the amount is negative due to rounding (near impossible), just revert (should be positive soon enough).
-        IaToken(aave).withdraw(underlying, tokenBalance.sub(balance), address(this));
-        uint256 amountAdded_ = IERC20(underlying).safeBalanceOf(address(this));
-        // @dev Transfer the profit to the bentobox, the amountAdded at this point matches the amount transferred.
-        IERC20(underlying).safeTransfer(address(bentobox), amountAdded_);
-        maxShare = 0; // nullify maxShare
-        return int256(amountAdded_);
+        // do not revert if conditions fail
+        if (sender == address(this) && IBentoBoxMinimal(bentobox).totals(underlying).elastic <= maxBentoBalance) {
+            // @dev Get the amount of tokens that the aTokens currently represent.
+            uint256 tokenBalance = IERC20(aToken).safeBalanceOf(address(this));
+            // @dev Convert enough aToken to take out the profit.
+            // If the amount is negative due to rounding (near impossible), just revert (should be positive soon enough).
+            IaToken(aave).withdraw(underlying, tokenBalance.sub(balance), address(this));
+            uint256 amountAdded_ = IERC20(underlying).safeBalanceOf(address(this));
+            // @dev Transfer the profit to the bentobox, the amountAdded at this point matches the amount transferred.
+            IERC20(underlying).safeTransfer(address(bentobox), amountAdded_);
+            maxBentoBalance = 0; // nullify maxShare
+            return int256(amountAdded_);
+        }
+
+        return 0;
     }
 
     /// @notice Withdraw assets.
@@ -196,37 +198,30 @@ contract AaveStrategy is IStrategy, BoringOwnable {
         require(exited, "AaveStrategy: not exited");
         (success, ) = to.call{value: value}(data);
     }
-    
+
     // **** SWAP ****
     // requires the initial amount to have already been sent to the first pair
-    function swapExactTokensForTokens(
-        uint256 amountOutMin,
-        address[] calldata path
-    ) public onlyOwner returns (uint256[] memory amounts) {
+    function swapExactTokensForTokens(uint256 amountOutMin, address[] calldata path) public onlyOwner returns (uint256[] memory amounts) {
         uint256 amountIn = IERC20(path[0]).safeBalanceOf(address(this));
         amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path);
         require(amounts[amounts.length - 1] >= amountOutMin, "AaveStrategy: insufficient output");
         IERC20(path[0]).safeTransfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, address(this));
-        emit LogConvert(
-            msg.sender,
-            path[0],
-            path[path.length - 1],
-            amountIn,
-            amounts[amounts.length - 1]
-        );
+        emit LogConvert(msg.sender, path[0], path[path.length - 1], amountIn, amounts[amounts.length - 1]);
     }
-    
-    function _swap(uint256[] memory amounts, address[] memory path, address _to) internal {
+
+    function _swap(
+        uint256[] memory amounts,
+        address[] memory path,
+        address _to
+    ) internal {
         for (uint256 i; i < path.length - 1; i++) {
             (address input, address output) = (path[i], path[i + 1]);
-            (address token0,) = UniswapV2Library.sortTokens(input, output);
+            (address token0, ) = UniswapV2Library.sortTokens(input, output);
             uint256 amountOut = amounts[i + 1];
             (uint256 amount0Out, uint256 amount1Out) = input == token0 ? (uint256(0), amountOut) : (amountOut, uint256(0));
             address to = i < path.length - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
-            IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output)).swap(
-                amount0Out, amount1Out, to, new bytes(0)
-            );
+            IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output)).swap(amount0Out, amount1Out, to, new bytes(0));
         }
     }
 }

--- a/contracts/strategies/BaseStrategy.sol
+++ b/contracts/strategies/BaseStrategy.sol
@@ -11,21 +11,20 @@ import "@boringcrypto/boring-solidity/contracts/libraries/BoringERC20.sol";
 import "@sushiswap/core/contracts/uniswapv2/libraries/UniswapV2Library.sol";
 
 abstract contract BaseStrategy is IStrategy, BoringOwnable {
-    
     using BoringMath for uint256;
     using BoringERC20 for IERC20;
 
     IERC20 public immutable underlying;
     IBentoBoxMinimal public immutable bentoBox;
     address public immutable factory;
-    
+
     bool public exited;
     uint256 public maxBentoBoxBalance;
     mapping(address => bool) public strategyExecutors;
     mapping(bytes32 => bool) public allowedPaths;
 
     event LogConvert(address indexed server, address indexed token0, address indexed token1, uint256 amount0, uint256 amount1);
-	event LogToggleStrategyExecutor(address indexed executor, bool allowed);
+    event LogToggleStrategyExecutor(address indexed executor, bool allowed);
 
     /** @param _underlying Token the strategy invests.
         @param _bentoBox BentoBox address.
@@ -35,50 +34,49 @@ abstract contract BaseStrategy is IStrategy, BoringOwnable {
     constructor(
         IERC20 _underlying,
         IBentoBoxMinimal _bentoBox,
-		address _strategyExecutor,
+        address _strategyExecutor,
         address _factory,
-		address[][] memory _allowedPaths
+        address[][] memory _allowedPaths
     ) public {
-        
-		underlying = _underlying;
+        underlying = _underlying;
         bentoBox = _bentoBox;
-		strategyExecutors[_strategyExecutor] = true;
+        strategyExecutors[_strategyExecutor] = true;
         factory = _factory;
-		
-		for (uint i = 0; i < _allowedPaths.length; i++) {
-			allowedPaths[keccak256(abi.encodePacked(_allowedPaths[i]))] = true;
-		}
+
+        for (uint256 i = 0; i < _allowedPaths.length; i++) {
+            allowedPaths[keccak256(abi.encodePacked(_allowedPaths[i]))] = true;
+        }
     }
 
-    modifier onlyBentobox {
+    modifier onlyBentobox() {
         // @dev Only BentoBox can call harvest on this strategy.
         require(msg.sender == address(bentoBox), "BentoBox Strategy: only bento");
         require(!exited, "BentoBox Strategy: exited");
         _;
     }
 
-	modifier onlyExecutor {
-		// @dev Only executors can call safeHarvest on this strategy.
-		require(strategyExecutors[msg.sender], "BentoBox Strategy: only executor");
-		_;
-	}
+    modifier onlyExecutor() {
+        // @dev Only executors can call safeHarvest on this strategy.
+        require(strategyExecutors[msg.sender], "BentoBox Strategy: only executor");
+        _;
+    }
 
-	function toggleStrategyExecutor(address executor) external onlyOwner {
-		strategyExecutors[executor] = !strategyExecutors[executor];
-		emit LogToggleStrategyExecutor(executor, strategyExecutors[executor]);
-	}
+    function toggleStrategyExecutor(address executor) external onlyOwner {
+        strategyExecutors[executor] = !strategyExecutors[executor];
+        emit LogToggleStrategyExecutor(executor, strategyExecutors[executor]);
+    }
 
     /// @inheritdoc IStrategy
     function skim(uint256 amount) external override {
-		_skim(amount);
-	}
+        _skim(amount);
+    }
 
-	/// @notice Invests the underlying asset.
+    /// @notice Invests the underlying asset.
     /// @param amount The amount of tokens to invest.
     /// @dev Assume the contract's balance is greater than the amount
-	function _skim(uint256 amount) internal virtual;
+    function _skim(uint256 amount) internal virtual;
 
-	/// @notice Harvest profits while preventing a sandwich attack exploit.
+    /// @notice Harvest profits while preventing a sandwich attack exploit.
     /// @param maxBalance The maximum balance of the underlying token that is allowed to be in BentoBox.
     /// @param rebalance Whether BentoBox should rebalance the strategy assets to acheive it's target allocation.
     /// @param maxChangeAmount When rebalancing - the maximum amount that can be deposited or withdrawn from a strategy.
@@ -94,14 +92,11 @@ abstract contract BaseStrategy is IStrategy, BoringOwnable {
 
     /// @inheritdoc IStrategy
     function harvest(uint256 balance, address sender) external override onlyBentobox returns (int256) {
-
-		/** @dev Ensures that (1) the caller was this contract (called through the safeHarvest function)
+        /** @dev Ensures that (1) the caller was this contract (called through the safeHarvest function)
 		    and (2) that we are not being frontrun by a large BentoBox deposit when harvesting profits.
 		    @dev Don't revert if conditions aren't met in order to allow
 		    BentoBox to continiue execution as it might need to do a rebalance. */
-		if (sender == address(this) && IBentoBoxMinimal(bentoBox).totals(address(underlying)).elastic <= maxBentoBoxBalance) {
-
-
+        if (sender == address(this) && IBentoBoxMinimal(bentoBox).totals(address(underlying)).elastic <= maxBentoBoxBalance) {
             /** @dev We might also have some underlying tokens in the contract from before so the amount
                 returned by the internal _harvest function isn't necessary the final profit/loss amount */
             int256 amount = _harvest(balance);
@@ -114,11 +109,10 @@ abstract contract BaseStrategy is IStrategy, BoringOwnable {
                     IERC20(underlying).safeTransfer(address(bentoBox), contractBalance);
                 }
                 return int256(contractBalance);
-
             } else if (contractBalance > 0) {
                 // we might have made a loss
                 int256 diff = amount + int256(contractBalance);
-                    
+
                 if (diff > 0) {
                     // we still made some profit
                     _skim(uint256(-amount));
@@ -129,21 +123,19 @@ abstract contract BaseStrategy is IStrategy, BoringOwnable {
                     _skim(contractBalance);
                     return diff;
                 }
-                
             } else {
                 // we made a loss
                 return amount;
             }
-
         }
         return int256(0);
     }
 
-	/// @notice Harvest any profits made and transfer them to address(this) or report a loss
+    /// @notice Harvest any profits made and transfer them to address(this) or report a loss
     /// @param balance The amount of tokens that have been invested.
     /// @return amountAdded The delta (+profit or -loss) that occured in contrast to `balance`.
     /// @dev amountAdded can be left at 0 when reporting profits (gas savings).
-	function _harvest(uint256 balance) internal virtual returns (int256 amountAdded);
+    function _harvest(uint256 balance) internal virtual returns (int256 amountAdded);
 
     /// @inheritdoc IStrategy
     function withdraw(uint256 amount) external override onlyBentobox returns (uint256 actualAmount) {
@@ -153,9 +145,9 @@ abstract contract BaseStrategy is IStrategy, BoringOwnable {
         IERC20(underlying).safeTransfer(address(bentoBox), actualAmount);
     }
 
-	/// @dev Withdraw the requested amount of the underlying tokens to address(this)
-	/// @param amount The requested amount the caller wants to withdraw.
-	function _withdraw(uint256 amount) internal virtual;
+    /// @dev Withdraw the requested amount of the underlying tokens to address(this)
+    /// @param amount The requested amount the caller wants to withdraw.
+    function _withdraw(uint256 amount) internal virtual;
 
     /// @inheritdoc IStrategy
     function exit(uint256 balance) external override onlyBentobox returns (int256 amountAdded) {
@@ -170,9 +162,9 @@ abstract contract BaseStrategy is IStrategy, BoringOwnable {
         exited = true;
     }
 
-	/// @notice Withdraw the maximum amount of the invested assets to address(this).
-	/// @dev This shouldn't revert (use try catch).
-	function _exit() internal virtual;
+    /// @notice Withdraw the maximum amount of the invested assets to address(this).
+    /// @dev This shouldn't revert (use try catch).
+    function _exit() internal virtual;
 
     function afterExit(
         address to,
@@ -186,33 +178,29 @@ abstract contract BaseStrategy is IStrategy, BoringOwnable {
     }
 
     // **** SWAP ****
-	/// @notice Swap some tokens in the contract
-	function swapExactTokensForTokens(
-		uint256 amountOutMin,
-		address[] calldata path
-	) public onlyExecutor returns (uint256[] memory amounts) {
+    /// @notice Swap some tokens in the contract
+    function swapExactTokensForTokens(uint256 amountOutMin, address[] calldata path) public onlyExecutor returns (uint256[] memory amounts) {
+        /// @dev prevent the owner from siphoning off profits by swapping through an illiquid path
+        require(allowedPaths[keccak256(abi.encodePacked(path))] || exited, "BentoBox Strategy: monkey business");
 
-		/// @dev prevent the owner from siphoning off profits by swapping through an illiquid path
-		require(allowedPaths[keccak256(abi.encodePacked(path))] || exited, "BentoBox Strategy: monkey business");
-		
-		uint256 amountIn = IERC20(path[0]).safeBalanceOf(address(this));
-		amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path);
-		require(amounts[amounts.length - 1] >= amountOutMin, "BentoBox Strategy: insufficient output");
-        
-		IERC20(path[0]).safeTransfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
-		_swap(amounts, path, address(this));
-        
-		emit LogConvert(msg.sender, path[0], path[path.length - 1], amountIn, amounts[amounts.length - 1]);
+        uint256 amountIn = IERC20(path[0]).safeBalanceOf(address(this));
+        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path);
+        require(amounts[amounts.length - 1] >= amountOutMin, "BentoBox Strategy: insufficient output");
+
+        IERC20(path[0]).safeTransfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
+        _swap(amounts, path, address(this));
+
+        emit LogConvert(msg.sender, path[0], path[path.length - 1], amountIn, amounts[amounts.length - 1]);
     }
 
-	/// @dev requires the initial amount to have already been sent to the first pair
+    /// @dev requires the initial amount to have already been sent to the first pair
     function _swap(
         uint256[] memory amounts,
         address[] memory path,
         address _to
     ) internal {
         for (uint256 i; i < path.length - 1; i++) {
-	        (address input, address output) = (path[i], path[i + 1]);
+            (address input, address output) = (path[i], path[i + 1]);
             (address token0, ) = UniswapV2Library.sortTokens(input, output);
             uint256 amountOut = amounts[i + 1];
             (uint256 amount0Out, uint256 amount1Out) = input == token0 ? (uint256(0), amountOut) : (amountOut, uint256(0));

--- a/contracts/strategies/BaseStrategy.sol
+++ b/contracts/strategies/BaseStrategy.sol
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "../interfaces/IStrategy.sol";
+import "../interfaces/IBentoBoxMinimal.sol";
+import "@boringcrypto/boring-solidity/contracts/BoringOwnable.sol";
+import "@boringcrypto/boring-solidity/contracts/libraries/BoringMath.sol";
+import "@boringcrypto/boring-solidity/contracts/libraries/BoringERC20.sol";
+import "@sushiswap/core/contracts/uniswapv2/libraries/UniswapV2Library.sol";
+
+abstract contract BaseStrategy is IStrategy, BoringOwnable {
+    
+    using BoringMath for uint256;
+    using BoringERC20 for IERC20;
+
+    IERC20 public immutable underlying;
+    IBentoBoxMinimal public immutable bentoBox;
+    address public immutable factory;
+    
+    bool public exited;
+    uint256 public maxBentoBoxBalance;
+    mapping(address => bool) public strategyExecutors;
+    mapping(bytes32 => bool) public allowedPaths;
+
+    event LogConvert(address indexed server, address indexed token0, address indexed token1, uint256 amount0, uint256 amount1);
+	event LogToggleStrategyExecutor(address indexed executor, bool allowed);
+
+    /** @param _underlying Token the strategy invests.
+        @param _bentoBox BentoBox address.
+        @param _strategyExecutor EOA that will execute the safeHarvest function.
+        @param _factory SushiSwap factory.
+        @param _allowedPaths Allowed trade paths to trade from any reward token to the underlying. */
+    constructor(
+        IERC20 _underlying,
+        IBentoBoxMinimal _bentoBox,
+		address _strategyExecutor,
+        address _factory,
+		address[][] memory _allowedPaths
+    ) public {
+        
+		underlying = _underlying;
+        bentoBox = _bentoBox;
+		strategyExecutors[_strategyExecutor] = true;
+        factory = _factory;
+		
+		for (uint i = 0; i < _allowedPaths.length; i++) {
+			allowedPaths[keccak256(abi.encodePacked(_allowedPaths[i]))] = true;
+		}
+    }
+
+    modifier onlyBentobox {
+        // @dev Only BentoBox can call harvest on this strategy.
+        require(msg.sender == address(bentoBox), "BentoBox Strategy: only bento");
+        require(!exited, "BentoBox Strategy: exited");
+        _;
+    }
+
+	modifier onlyExecutor {
+		// @dev Only executors can call safeHarvest on this strategy.
+		require(strategyExecutors[msg.sender], "BentoBox Strategy: only executor");
+		_;
+	}
+
+	function toggleStrategyExecutor(address executor) external onlyOwner {
+		strategyExecutors[executor] = !strategyExecutors[executor];
+		emit LogToggleStrategyExecutor(executor, strategyExecutors[executor]);
+	}
+
+    /// @inheritdoc IStrategy
+    function skim(uint256 amount) external override {
+		_skim(amount);
+	}
+
+	/// @notice Invests the underlying asset.
+    /// @param amount The amount of tokens to invest.
+    /// @dev Assume the contract's balance is greater than the amount
+	function _skim(uint256 amount) internal virtual;
+
+	/// @notice Harvest profits while preventing a sandwich attack exploit.
+    /// @param maxBalance The maximum balance of the underlying token that is allowed to be in BentoBox.
+    /// @param rebalance Whether BentoBox should rebalance the strategy assets to acheive it's target allocation.
+    /// @param maxChangeAmount When rebalancing - the maximum amount that can be deposited or withdrawn from a strategy.
+    /// @dev maxChangeAmount can be set to 0 to allow for full rebalancing.
+    function safeHarvest(
+        uint256 maxBalance,
+        bool rebalance,
+        uint256 maxChangeAmount
+    ) external onlyExecutor {
+        maxBentoBoxBalance = maxBalance;
+        bentoBox.harvest(address(underlying), rebalance, maxChangeAmount);
+    }
+
+    /// @inheritdoc IStrategy
+    function harvest(uint256 balance, address sender) external override onlyBentobox returns (int256) {
+
+		/** @dev Ensures that (1) the caller was this contract (called through the safeHarvest function)
+		    and (2) that we are not being frontrun by a large BentoBox deposit when harvesting profits.
+		    @dev Don't revert if conditions aren't met in order to allow
+		    BentoBox to continiue execution as it might need to do a rebalance. */
+		if (sender == address(this) && IBentoBoxMinimal(bentoBox).totals(address(underlying)).elastic <= maxBentoBoxBalance) {
+
+
+            /** @dev We might also have some underlying tokens in the contract from before so the amount
+                returned by the internal _harvest function isn't necessary the final profit/loss amount */
+            int256 amount = _harvest(balance);
+
+            uint256 contractBalance = IERC20(underlying).safeBalanceOf(address(this));
+
+            if (amount >= 0) {
+                // we made some profit
+                if (contractBalance > 0) {
+                    IERC20(underlying).safeTransfer(address(bentoBox), contractBalance);
+                }
+                return int256(contractBalance);
+
+            } else if (contractBalance > 0) {
+                // we might have made a loss
+                int256 diff = amount + int256(contractBalance);
+                    
+                if (diff > 0) {
+                    // we still made some profit
+                    _skim(uint256(-amount));
+                    IERC20(underlying).safeTransfer(address(bentoBox), uint256(diff));
+                    return diff;
+                } else {
+                    // we made a loss but we have some tokens we can reinvest
+                    _skim(contractBalance);
+                    return diff;
+                }
+                
+            } else {
+                // we made a loss
+                return amount;
+            }
+
+        }
+        return int256(0);
+    }
+
+	/// @notice Harvest any profits made and transfer them to address(this) or report a loss
+    /// @param balance The amount of tokens that have been invested.
+    /// @return amountAdded The delta (+profit or -loss) that occured in contrast to `balance`.
+    /// @dev amountAdded can be left at 0 when reporting profits (gas savings).
+	function _harvest(uint256 balance) internal virtual returns (int256 amountAdded);
+
+    /// @inheritdoc IStrategy
+    function withdraw(uint256 amount) external override onlyBentobox returns (uint256 actualAmount) {
+        _withdraw(amount);
+        /// @dev Make sure we send and report the exact same amount of tokens by using balanceOf.
+        actualAmount = IERC20(underlying).safeBalanceOf(address(this));
+        IERC20(underlying).safeTransfer(address(bentoBox), actualAmount);
+    }
+
+	/// @dev Withdraw the requested amount of the underlying tokens to address(this)
+	/// @param amount The requested amount the caller wants to withdraw.
+	function _withdraw(uint256 amount) internal virtual;
+
+    /// @inheritdoc IStrategy
+    function exit(uint256 balance) external override onlyBentobox returns (int256 amountAdded) {
+        _exit();
+        /// @dev Check balance of token on the contract.
+        uint256 actualBalance = IERC20(underlying).safeBalanceOf(address(this));
+        /// @dev Calculate tokens added (or lost).
+        amountAdded = int256(actualBalance) - int256(balance);
+        /// @dev Transfer all tokens to bentoBox.
+        underlying.safeTransfer(address(bentoBox), actualBalance);
+        /// @dev Flag as exited, allowing the owner to manually deal with any amounts available later.
+        exited = true;
+    }
+
+	/// @notice Withdraw the maximum amount of the invested assets to address(this).
+	/// @dev This shouldn't revert (use try catch).
+	function _exit() internal virtual;
+
+    function afterExit(
+        address to,
+        uint256 value,
+        bytes memory data
+    ) public onlyOwner returns (bool success) {
+        /** @dev After exited, the owner can perform ANY call. This is to rescue any funds that didn't
+			get released during exit or got earned afterwards due to vesting or airdrops, etc. */
+        require(exited, "BentoBox Strategy: not exited");
+        (success, ) = to.call{value: value}(data);
+    }
+
+    // **** SWAP ****
+	/// @notice Swap some tokens in the contract
+	function swapExactTokensForTokens(
+		uint256 amountOutMin,
+		address[] calldata path
+	) public onlyExecutor returns (uint256[] memory amounts) {
+
+		/// @dev prevent the owner from siphoning off profits by swapping through an illiquid path
+		require(allowedPaths[keccak256(abi.encodePacked(path))] || exited, "BentoBox Strategy: monkey business");
+		
+		uint256 amountIn = IERC20(path[0]).safeBalanceOf(address(this));
+		amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path);
+		require(amounts[amounts.length - 1] >= amountOutMin, "BentoBox Strategy: insufficient output");
+        
+		IERC20(path[0]).safeTransfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
+		_swap(amounts, path, address(this));
+        
+		emit LogConvert(msg.sender, path[0], path[path.length - 1], amountIn, amounts[amounts.length - 1]);
+    }
+
+	/// @dev requires the initial amount to have already been sent to the first pair
+    function _swap(
+        uint256[] memory amounts,
+        address[] memory path,
+        address _to
+    ) internal {
+        for (uint256 i; i < path.length - 1; i++) {
+	        (address input, address output) = (path[i], path[i + 1]);
+            (address token0, ) = UniswapV2Library.sortTokens(input, output);
+            uint256 amountOut = amounts[i + 1];
+            (uint256 amount0Out, uint256 amount1Out) = input == token0 ? (uint256(0), amountOut) : (amountOut, uint256(0));
+            address to = i < path.length - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
+            IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output)).swap(amount0Out, amount1Out, to, new bytes(0));
+        }
+    }
+}

--- a/contracts/strategies/SushiStrategy.sol
+++ b/contracts/strategies/SushiStrategy.sol
@@ -7,53 +7,52 @@ import "./BaseStrategy.sol";
 
 interface ISushiBar is IERC20 {
     function enter(uint256 _amount) external;
+
     function leave(uint256 _share) external;
 }
 
 contract SushiStrategy is BaseStrategy {
+    ISushiBar private immutable sushiBar;
 
-	ISushiBar private immutable sushiBar;
-
-	constructor(
-		IERC20 _underlying,
+    constructor(
+        IERC20 _underlying,
         IBentoBoxMinimal _bentoBox,
         address _factory,
-		address _strategyExecutor,
+        address _strategyExecutor,
         ISushiBar _sushiBar,
-		address[][] memory paths
+        address[][] memory paths
     ) public BaseStrategy(_underlying, _bentoBox, _factory, _strategyExecutor, paths) {
-		sushiBar = _sushiBar;
-		_underlying.approve(address(_sushiBar), type(uint256).max);
-	}
+        sushiBar = _sushiBar;
+        _underlying.approve(address(_sushiBar), type(uint256).max);
+    }
 
-	function _skim(uint256 amount) internal override {
-		sushiBar.enter(amount);	
-	}
+    function _skim(uint256 amount) internal override {
+        sushiBar.enter(amount);
+    }
 
-	function _harvest(uint256 balance) internal override returns (int256) {
+    function _harvest(uint256 balance) internal override returns (int256) {
         uint256 keep = toShare(balance);
-		uint256 total = sushiBar.balanceOf(address(this));
-		if (total > keep) {
-			sushiBar.leave(total - keep);
-		}
-		// xSUSHI can't report a loss so no need to check for keep < total case
-		return int256(0);
-	}
+        uint256 total = sushiBar.balanceOf(address(this));
+        if (total > keep) {
+            sushiBar.leave(total - keep);
+        }
+        // xSUSHI can't report a loss so no need to check for keep < total case
+        return int256(0);
+    }
 
-	function _withdraw(uint256 amount) internal override {
+    function _withdraw(uint256 amount) internal override {
         uint256 requested = toShare(amount);
-		uint256 actual = sushiBar.balanceOf(address(this));
+        uint256 actual = sushiBar.balanceOf(address(this));
         sushiBar.leave(requested > actual ? actual : requested);
-	}
+    }
 
-	function _exit() internal override {
+    function _exit() internal override {
         sushiBar.leave(sushiBar.balanceOf(address(this)));
-	}
+    }
 
-	function toShare(uint256 amount) internal view returns (uint256) {
-		uint256 totalShares = sushiBar.totalSupply();
+    function toShare(uint256 amount) internal view returns (uint256) {
+        uint256 totalShares = sushiBar.totalSupply();
         uint256 totalSushi = underlying.safeBalanceOf(address(sushiBar));
-		return amount.mul(totalShares) / totalSushi;
-	}
-
+        return amount.mul(totalShares) / totalSushi;
+    }
 }

--- a/contracts/strategies/old/AaveStrategy.sol
+++ b/contracts/strategies/old/AaveStrategy.sol
@@ -3,8 +3,8 @@
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
-import "../interfaces/IStrategy.sol";
-import "../interfaces/IBentoBoxMinimal.sol";
+import "../../interfaces/IStrategy.sol";
+import "../../interfaces/IBentoBoxMinimal.sol";
 import "@boringcrypto/boring-solidity/contracts/BoringOwnable.sol";
 import "@boringcrypto/boring-solidity/contracts/libraries/BoringMath.sol";
 import "@boringcrypto/boring-solidity/contracts/libraries/BoringERC20.sol";
@@ -89,7 +89,7 @@ contract AaveStrategy is IStrategy, BoringOwnable {
         bentobox = bentobox_;
         underlying = underlying_;
         IERC20(underlying_).approve(aave_, type(uint256).max);
-        aToken = IaToken(aaveLendingPool).getReserveData(underlying_).aTokenAddress;
+        aToken = IaToken(aave_).getReserveData(underlying_).aTokenAddress;
     }
 
     modifier onlyBentobox {

--- a/contracts/strategies/old/AaveStrategy.sol
+++ b/contracts/strategies/old/AaveStrategy.sol
@@ -92,7 +92,7 @@ contract AaveStrategy is IStrategy, BoringOwnable {
         aToken = IaToken(aave_).getReserveData(underlying_).aTokenAddress;
     }
 
-    modifier onlyBentobox {
+    modifier onlyBentobox() {
         // @dev Only the bentobox can call harvest on this strategy.
         require(msg.sender == address(bentobox), "AaveStrategy: only bento");
         require(!exited, "AaveStrategy: exited");

--- a/contracts/strategies/old/CompoundStrategy.sol
+++ b/contracts/strategies/old/CompoundStrategy.sol
@@ -81,7 +81,7 @@ contract CompoundStrategy is IStrategy, BoringOwnable {
         token_.approve(address(cToken_), type(uint256).max);
     }
 
-    modifier onlyBentobox {
+    modifier onlyBentobox() {
         // Only the bentobox can call harvest on this strategy
         require(msg.sender == bentobox, "CompoundStrategy: only bento");
         require(!exited, "CompoundStrategy: exited");

--- a/contracts/strategies/old/CompoundStrategy.sol
+++ b/contracts/strategies/old/CompoundStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
-import "../interfaces/IStrategy.sol";
+import "../../interfaces/IStrategy.sol";
 import "@boringcrypto/boring-solidity/contracts/BoringOwnable.sol";
 import "@boringcrypto/boring-solidity/contracts/libraries/BoringMath.sol";
 import "@boringcrypto/boring-solidity/contracts/libraries/BoringERC20.sol";

--- a/package.json
+++ b/package.json
@@ -122,6 +122,6 @@
         "typechain-target-ethers-v5": "^5.0.1"
     },
     "dependencies": {
-        "@boringcrypto/boring-solidity": "boringcrypto/BoringSolidity#8f2b54f645a7844ae266cc50dc3ae4c125c7b9fc"
+        "@boringcrypto/boring-solidity": "boringcrypto/BoringSolidity#77f3752c4bcf47cb7f8e8140ac8cd626b1151ad3"
     }
 }

--- a/test/AaveStrategy.js
+++ b/test/AaveStrategy.js
@@ -4,12 +4,12 @@ const { ethers } = require("hardhat")
 
 let cmd, fixture
 
-describe.only("AaveStrategy", function () {
+describe("AaveStrategy", function () {
     const aave = "0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9"
     const factory = "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac"
     const usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
 
-    before(async function () {
+    /* before(async function () {
         fixture = await createFixture(deployments, this, async (cmd) => {
             await cmd.deploy("sushi", "RevertingERC20Mock", "SUSHI", "SUSHI", 18, getBigNumber("10000000"))
             await cmd.deploy("weth9", "WETH9Mock")
@@ -19,5 +19,5 @@ describe.only("AaveStrategy", function () {
             // await cmd.deploy("aaveStrategy", "AaveStrategy", aave, factory, this.bentoBox.address, usdc)
         })
         cmd = await fixture()
-    })
+    }) */
 })

--- a/test/AaveStrategy.js
+++ b/test/AaveStrategy.js
@@ -1,0 +1,24 @@
+const { ADDRESS_ZERO, setMasterContractApproval, createFixture, getBigNumber, advanceTime } = require("./utilities")
+const { expect } = require("chai")
+const { ethers } = require("hardhat")
+
+let cmd, fixture
+
+describe.only("AaveStrategy", function () {
+    const aave = "0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9"
+    const factory = "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac"
+    const usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+    before(async function () {
+        fixture = await createFixture(deployments, this, async (cmd) => {
+            await cmd.deploy("sushi", "RevertingERC20Mock", "SUSHI", "SUSHI", 18, getBigNumber("10000000"))
+            await cmd.deploy("weth9", "WETH9Mock")
+            await cmd.deploy("bentoBox", "BentoBoxMock", this.weth9.address)
+            await cmd.deploy("bar", "SushiBarMock", this.sushi.address)
+            await cmd.deploy("sushiStrategy", "SushiStrategy", this.bar.address, this.sushi.address)
+            // await cmd.deploy("aaveStrategy", "AaveStrategy", aave, factory, this.bentoBox.address, usdc)
+        })
+        cmd = await fixture()
+    })
+
+})

--- a/test/AaveStrategy.js
+++ b/test/AaveStrategy.js
@@ -20,5 +20,4 @@ describe.only("AaveStrategy", function () {
         })
         cmd = await fixture()
     })
-
 })

--- a/test/StrategyManager.js
+++ b/test/StrategyManager.js
@@ -11,8 +11,16 @@ describe("StrategyManager", function () {
             await cmd.deploy("weth9", "WETH9Mock")
             await cmd.deploy("bentoBox", "BentoBoxMock", this.weth9.address)
             await cmd.deploy("bar", "SushiBarMock", this.sushi.address)
-            await cmd.deploy("sushiStrategy", "SushiStrategy", this.sushi.address, this.bentoBox.address,
-                "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac", this.alice.address, this.bar.address, [])
+            await cmd.deploy(
+                "sushiStrategy",
+                "SushiStrategy",
+                this.sushi.address,
+                this.bentoBox.address,
+                "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac",
+                this.alice.address,
+                this.bar.address,
+                []
+            )
             await this.sushi.approve(this.bar.address, getBigNumber(1))
             await this.bar.enter(getBigNumber(1))
             await this.sushiStrategy.toggleStrategyExecutor(this.alice.address)
@@ -41,10 +49,9 @@ describe("StrategyManager", function () {
         })
 
         it("safeHarvest reverts if not called by executor", async function () {
-            await expect(this.sushiStrategy.connect(this.bob).safeHarvest((await this.bentoBox.totals(this.sushi.address)).elastic, true, 0))
-                .to.be.revertedWith(
-                    "BentoBox Strategy: only executor"
-                )
+            await expect(
+                this.sushiStrategy.connect(this.bob).safeHarvest((await this.bentoBox.totals(this.sushi.address)).elastic, true, 0)
+            ).to.be.revertedWith("BentoBox Strategy: only executor")
         })
 
         it("should rebalance the token", async function () {
@@ -72,8 +79,16 @@ describe("StrategyManager", function () {
         })
 
         it("switches to new strategy and exits from old", async function () {
-            await cmd.deploy("sushiStrategy2", "SushiStrategy", this.sushi.address, this.bentoBox.address,
-                "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac", this.alice.address, this.bar.address, [])
+            await cmd.deploy(
+                "sushiStrategy2",
+                "SushiStrategy",
+                this.sushi.address,
+                this.bentoBox.address,
+                "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac",
+                this.alice.address,
+                this.bar.address,
+                []
+            )
             await this.bentoBox.setStrategy(this.sushi.address, this.sushiStrategy2.address)
             await advanceTime(1209600, ethers)
             await this.bentoBox.setStrategy(this.sushi.address, this.sushiStrategy2.address)
@@ -91,8 +106,16 @@ describe("StrategyManager", function () {
 
         it("switches to new strategy and exits from old with profit", async function () {
             await this.sushi.transfer(this.bar.address, getBigNumber(1))
-            await cmd.deploy("sushiStrategy3", "SushiStrategy", this.sushi.address, this.bentoBox.address,
-                "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac", this.alice.address, this.bar.address, [])
+            await cmd.deploy(
+                "sushiStrategy3",
+                "SushiStrategy",
+                this.sushi.address,
+                this.bentoBox.address,
+                "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac",
+                this.alice.address,
+                this.bar.address,
+                []
+            )
             await this.bentoBox.setStrategy(this.sushi.address, this.sushiStrategy3.address)
             await advanceTime(1209600, ethers)
             await this.bentoBox.setStrategy(this.sushi.address, this.sushiStrategy3.address)
@@ -102,9 +125,17 @@ describe("StrategyManager", function () {
 
         it("stores valid path", async function () {
             const fakePath = ["0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac", "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac"]
-            await cmd.deploy("sushiStrategy4", "SushiStrategy", this.sushi.address, this.bentoBox.address,
-                "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac", this.alice.address, this.bar.address, [fakePath]);
-            const hash = ethers.utils.keccak256(ethers.utils.solidityPack(["address[][]"], [[fakePath]]));
+            await cmd.deploy(
+                "sushiStrategy4",
+                "SushiStrategy",
+                this.sushi.address,
+                this.bentoBox.address,
+                "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac",
+                this.alice.address,
+                this.bar.address,
+                [fakePath]
+            )
+            const hash = ethers.utils.keccak256(ethers.utils.solidityPack(["address[][]"], [[fakePath]]))
             expect(await this.sushiStrategy4.allowedPaths(hash)).to.be.true
         })
     })

--- a/test/StrategyManager.js
+++ b/test/StrategyManager.js
@@ -11,10 +11,11 @@ describe("StrategyManager", function () {
             await cmd.deploy("weth9", "WETH9Mock")
             await cmd.deploy("bentoBox", "BentoBoxMock", this.weth9.address)
             await cmd.deploy("bar", "SushiBarMock", this.sushi.address)
-            await cmd.deploy("sushiStrategy", "SushiStrategy", this.bar.address, this.sushi.address)
-            await this.sushiStrategy.transferOwnership(this.bentoBox.address, true, false)
+            await cmd.deploy("sushiStrategy", "SushiStrategy", this.sushi.address, this.bentoBox.address,
+                "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac", this.alice.address, this.bar.address, [])
             await this.sushi.approve(this.bar.address, getBigNumber(1))
             await this.bar.enter(getBigNumber(1))
+            await this.sushiStrategy.toggleStrategyExecutor(this.alice.address)
         })
         cmd = await fixture()
     })
@@ -39,6 +40,13 @@ describe("StrategyManager", function () {
             )
         })
 
+        it("safeHarvest reverts if not called by executor", async function () {
+            await expect(this.sushiStrategy.connect(this.bob).safeHarvest((await this.bentoBox.totals(this.sushi.address)).elastic, true, 0))
+                .to.be.revertedWith(
+                    "BentoBox Strategy: only executor"
+                )
+        })
+
         it("should rebalance the token", async function () {
             await this.sushi.approve(this.bentoBox.address, getBigNumber(10))
             await this.bentoBox.deposit(this.sushi.address, this.alice.address, this.alice.address, getBigNumber(10), 0)
@@ -55,13 +63,17 @@ describe("StrategyManager", function () {
 
         it("rebalances correctly after SushiBar makes money", async function () {
             await this.sushi.transfer(this.bar.address, getBigNumber(10))
-            await this.bentoBox.harvest(this.sushi.address, true, 0)
+            await this.sushiStrategy.safeHarvest((await this.bentoBox.totals(this.sushi.address)).elastic.sub(1), true, 0)
+            expect((await this.bentoBox.strategyData(this.sushi.address)).balance).to.be.equal("8000000000000000000")
+            expect(await this.sushi.balanceOf(this.bentoBox.address)).to.be.equal("2000000000000000000")
+            await this.sushiStrategy.safeHarvest((await this.bentoBox.totals(this.sushi.address)).elastic, true, 0)
             expect((await this.bentoBox.strategyData(this.sushi.address)).balance).to.be.equal("15111111111111111112")
             expect(await this.sushi.balanceOf(this.bentoBox.address)).to.be.equal("3777777777777777778")
         })
 
         it("switches to new strategy and exits from old", async function () {
-            await cmd.deploy("sushiStrategy2", "SushiStrategy", this.bar.address, this.sushi.address)
+            await cmd.deploy("sushiStrategy2", "SushiStrategy", this.sushi.address, this.bentoBox.address,
+                "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac", this.alice.address, this.bar.address, [])
             await this.bentoBox.setStrategy(this.sushi.address, this.sushiStrategy2.address)
             await advanceTime(1209600, ethers)
             await this.bentoBox.setStrategy(this.sushi.address, this.sushiStrategy2.address)
@@ -69,27 +81,31 @@ describe("StrategyManager", function () {
             expect((await this.bentoBox.totals(this.sushi.address)).elastic).to.be.equal("18888888888888888888")
         })
 
-        it("SushiStrategy does not allow to draw a too high share", async function () {
-            await this.sushiStrategy2.withdraw(getBigNumber(1))
-        })
-
         it("rebalances correctly after a withdraw from BentoBox", async function () {
-            await this.sushiStrategy2.transferOwnership(this.bentoBox.address, true, false)
-            await this.bentoBox.harvest(this.sushi.address, true, 0)
+            await this.sushiStrategy.safeHarvest((await this.bentoBox.totals(this.sushi.address)).elastic, true, 0)
             await this.bentoBox.withdraw(this.sushi.address, this.alice.address, this.alice.address, "3677777777777777778", 0)
-            await this.bentoBox.harvest(this.sushi.address, true, 0)
+            await this.sushiStrategy.safeHarvest((await this.bentoBox.totals(this.sushi.address)).elastic, true, 0)
             expect(await this.sushi.balanceOf(this.bentoBox.address)).to.be.equal("3042222222222222220")
             expect((await this.bentoBox.totals(this.sushi.address)).elastic).to.be.equal("15211111111111111110")
         })
 
         it("switches to new strategy and exits from old with profit", async function () {
             await this.sushi.transfer(this.bar.address, getBigNumber(1))
-            await cmd.deploy("sushiStrategy3", "SushiStrategy", this.bar.address, this.sushi.address)
+            await cmd.deploy("sushiStrategy3", "SushiStrategy", this.sushi.address, this.bentoBox.address,
+                "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac", this.alice.address, this.bar.address, [])
             await this.bentoBox.setStrategy(this.sushi.address, this.sushiStrategy3.address)
             await advanceTime(1209600, ethers)
             await this.bentoBox.setStrategy(this.sushi.address, this.sushiStrategy3.address)
             expect(await this.sushi.balanceOf(this.bentoBox.address)).to.be.equal("16063274198568316213")
             expect((await this.bentoBox.totals(this.sushi.address)).elastic).to.be.equal("16063274198568316213")
+        })
+
+        it("stores valid path", async function () {
+            const fakePath = ["0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac", "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac"]
+            await cmd.deploy("sushiStrategy4", "SushiStrategy", this.sushi.address, this.bentoBox.address,
+                "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac", this.alice.address, this.bar.address, [fakePath]);
+            const hash = ethers.utils.keccak256(ethers.utils.solidityPack(["address[][]"], [[fakePath]]));
+            expect(await this.sushiStrategy4.allowedPaths(hash)).to.be.true
         })
     })
 })


### PR DESCRIPTION
Add an abstract contract for BentoBox strategies. The abstract contract makes the harvest function effectively private and minimizes the risk of a sandwich attack exploit. 

To write a strategy extend the abstract contract and implement the _skim, _harvest, _withdraw, and _exit functions.