### PR TITLE
feat: yearn vault strategy

### DIFF
--- a/contracts/strategies/YearnVaultStrategy.sol
+++ b/contracts/strategies/YearnVaultStrategy.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import {BaseStrategy as BentoBaseStrategy} from "./BaseStrategy.sol";
+import "../interfaces/IBentoBoxMinimal.sol";
+import "@boringcrypto/boring-solidity/contracts/libraries/BoringERC20.sol";
+import {
+    BaseWrapper as YearnBaseWrapper
+} from "@yearn/yearn-vaults/contracts/BaseWrapper.sol";
+
+contract YearnVaultStrategy is YearnBaseWrapper, BentoBaseStrategy {
+    using BoringERC20 for IERC20;
+
+    constructor(
+        IERC20 _underlying,
+        address _yRegistry,
+        IBentoBoxMinimal _bentoBox,
+        address _strategyExecutor
+    )
+        public
+        YearnBaseWrapper(address(_underlying), _yRegistry)
+        BentoBaseStrategy(
+            BentoBaseStrategy.BaseStrategyParams(
+                _underlying,
+                _bentoBox,
+                _strategyExecutor,
+                address(0), // no rewards, so factory is not needed
+                address(0)  // no rewards, no bridgeToken token
+            )
+        )
+    {}
+
+    function _skim(uint256 amount) internal override {
+        super._deposit(address(this), address(this), amount, false);
+    }
+
+    function _harvest(uint256 balance)
+        internal
+        override
+        returns (int256 amountAdded)
+    {
+        amountAdded =
+            int256(super.totalVaultBalance(address(this))) -
+            int256(balance);
+        if (amountAdded > 0) {
+            _withdraw(uint256(amountAdded));
+        }
+    }
+
+    function _withdraw(uint256 amount) internal override {
+        super._withdraw(address(this), address(this), amount, true);
+    }
+
+    function _exit() internal override {
+        _withdraw(type(uint256).max);
+    }
+
+    function migrate(uint256 amount, uint256 maxMigrationLoss)
+        external
+        onlyOwner
+        returns (uint256)
+    {
+        return super._migrate(address(this), amount, maxMigrationLoss);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
         "@tenderly/hardhat-tenderly": "^1.0.10",
         "@uniswap/lib": "^2.2.0-alpha",
         "@uniswap/v2-core": "^1.0.1",
+        "@yearn/yearn-vaults": "github:yearn/yearn-vaults#bfcf7383eea17d7ce135f5b1ab2a4e2e88e149c9",
+        "@openzeppelin": "github:OpenZeppelin/openzeppelin-contracts#3.1.0",
         "big-integer": "^1.6.48",
         "chai": "^4.3.0",
         "coveralls": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,9 +23,9 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@boringcrypto/boring-solidity@boringcrypto/BoringSolidity#8f2b54f645a7844ae266cc50dc3ae4c125c7b9fc":
-  version "1.2.0"
-  resolved "https://codeload.github.com/boringcrypto/BoringSolidity/tar.gz/8f2b54f645a7844ae266cc50dc3ae4c125c7b9fc"
+"@boringcrypto/boring-solidity@boringcrypto/BoringSolidity#77f3752c4bcf47cb7f8e8140ac8cd626b1151ad3":
+  version "1.2.3"
+  resolved "https://codeload.github.com/boringcrypto/BoringSolidity/tar.gz/77f3752c4bcf47cb7f8e8140ac8cd626b1151ad3"
 
 "@codechecks/client@^0.1.10":
   version "0.1.10"
@@ -884,6 +884,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
+"@openzeppelin@github:OpenZeppelin/openzeppelin-contracts#3.1.0":
+  version "3.1.0"
+  resolved "https://codeload.github.com/OpenZeppelin/openzeppelin-contracts/tar.gz/de99bccbfd4ecd19d7369d01b070aa72c64423c9"
+
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@resolver-engine/core/-/core-0.3.3.tgz#590f77d85d45bc7ecc4e06c654f41345db6ca967"
@@ -1398,6 +1402,10 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
+"@yearn/yearn-vaults@github:yearn/yearn-vaults#bfcf7383eea17d7ce135f5b1ab2a4e2e88e149c9":
+  version "0.0.0"
+  resolved "https://codeload.github.com/yearn/yearn-vaults/tar.gz/bfcf7383eea17d7ce135f5b1ab2a4e2e88e149c9"
 
 abbrev@1:
   version "1.1.1"


### PR DESCRIPTION
A bentobox strategy that implements yearn vault `BaseWrapper` and @gasperbr's `BaseStrategy` depositing into the appropriate yearn vault for a given token

Additional tests can be found here: https://github.com/fp-crypto/yearn-bento-strategy/tree/main/tests